### PR TITLE
Format Modal Dates

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -53,6 +53,19 @@ const App = () => {
       padNumberWith0Zero(date.getDate()),
     ].join("-");
   };
+
+  const modalDateFormat = (selectedEventDate: Date) =>
+    `${selectedEventDate.toLocaleString("default", {
+      weekday: "long",
+    })}, ${selectedEventDate.toLocaleString("default", {
+      month: "long",
+    })} ${selectedEventDate.getDate()}
+    ${selectedEventDate.toLocaleTimeString("default", {
+      hour: "2-digit",
+      minute: "2-digit",
+    })}
+    `;
+
   const DEFAULT_DATE = formatDate(new Date());
 
   const [startDate, setStartDate] = useState<string>(DEFAULT_DATE);
@@ -231,9 +244,12 @@ const App = () => {
               <p>Event title: {displayedEventData.title}</p>
               <p>Description: {displayedEventData.description}</p>
               <p>
-                Start: {new Date(displayedEventData.startTimeUtc).toString()}
+                Start:{" "}
+                {modalDateFormat(new Date(displayedEventData.startTimeUtc))}
               </p>
-              <p>End: {new Date(displayedEventData.endTimeUtc).toString()}</p>
+              <p>
+                End: {modalDateFormat(new Date(displayedEventData.endTimeUtc))}
+              </p>
             </ModalBody>
 
             <ModalFooter>


### PR DESCRIPTION
_Closes:_ https://github.com/insightorchards/calendar-ui/issues/42

## Summary of changes
Updated UTC time string to be user readable date in entry details modal.

## Dev notes
Was not able to be fully tested in this PR but will be test in this ticket: https://github.com/insightorchards/calendar-ui/issues/44
## Testing

- [x] Unit tests

#### Screenshot of UI (local testing in browser)
![image](https://user-images.githubusercontent.com/50315144/203486715-4583c415-e547-4ccd-8d54-04d4d9ca9d62.png)
