### PR TITLE
Reset values to empty post form submit

### DIFF
--- a/ui/src/EventForm.test.tsx
+++ b/ui/src/EventForm.test.tsx
@@ -158,10 +158,10 @@ describe("EventForm", () => {
     await waitFor(() => {
       userEvent.click(screen.getByRole("button", { name: "Create Event" }));
     });
-    expect(screen.getByLabelText("Start Date")).toHaveValue("2022-02-15");
-    expect(screen.getByLabelText("End Date")).toHaveValue("2022-02-15");
-    expect(screen.getByLabelText("Start Time")).toHaveValue("04:00");
-    expect(screen.getByLabelText("End Time")).toHaveValue("05:00");
+    expect(screen.getByLabelText("Start Date")).toHaveValue("");
+    expect(screen.getByLabelText("End Date")).toHaveValue("");
+    expect(screen.getByLabelText("Start Time")).toHaveValue("");
+    expect(screen.getByLabelText("End Time")).toHaveValue("");
     expect(screen.getByLabelText("All Day")).not.toBeChecked();
   });
 });

--- a/ui/src/EventForm.tsx
+++ b/ui/src/EventForm.tsx
@@ -56,10 +56,10 @@ const EventForm = ({
       setTitle(initialTitle);
       setDescription(initialDescription);
       setError(null);
-      setStartDate(initialStartDate);
-      setEndDate(initialEndDate);
-      setStartTime(initialStartTime);
-      setEndTime(initialEndTime);
+      setStartDate("");
+      setEndDate("");
+      setStartTime("");
+      setEndTime("");
       setAllDay(initialAllDay);
     }
   };


### PR DESCRIPTION
_Closes:_ #63 

## Summary of changes
This change updates the form to reset to empty values post submit. By setting the values to empty strings, we get the mm/dd/yyyy and --:-- values in the UI.

## Dev notes

## Testing

- [ ] Unit tests

#### Screenshot of UI (local testing in browser)
![Screen Shot 2022-12-10 at 2 14 57 PM](https://user-images.githubusercontent.com/15992415/206877317-a97d98fb-fcd2-4f5d-86f3-f410dff48c52.png)
