### PR TITLE
Set end date automatically when start date is selected

### DIFF
--- a/e2e/cypress/e2e/spec.cy.js
+++ b/e2e/cypress/e2e/spec.cy.js
@@ -19,6 +19,7 @@ describe("journey test", () => {
     cy.contains("label", "Title").click().type("Hello");
     cy.contains("label", "Description").click().type("It's a beautiful day");
     cy.contains("label", "Start Date").click().type("2022-11-26");
+    cy.get("#endDate").should("have.value", "2022-11-26");
     cy.contains("label", "End Date").click().type("2022-11-27");
     cy.contains("label", "Start Time").click().type("04:35");
     cy.contains("label", "End Time").click().type("06:45");

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -209,7 +209,7 @@ describe("App", () => {
       });
     });
 
-    it("errors when end date is before start date", async () => {
+    it("automatically sets end date when start date is selected", async () => {
       mockCreateEntry.mockResolvedValue({});
       mockGetEntries.mockResolvedValue([
         {
@@ -224,6 +224,22 @@ describe("App", () => {
       userEvent.type(screen.getByLabelText("Start Date"), "2016-12-12");
       expect(screen.getByLabelText("Start Date")).toHaveValue("2016-12-12");
       expect(screen.getByLabelText("End Date")).toHaveValue("2016-12-12");
+    });
+
+    it("errors when end date is before start date", async () => {
+      mockCreateEntry.mockResolvedValue({});
+      mockGetEntries.mockResolvedValue([
+        {
+          end: "2022-02-27T05:43:37.868Z",
+          start: "2022-02-27T05:43:37.868Z",
+          title: "Berta goes to the baseball game!",
+        },
+      ]);
+      await act(async () => {
+        await render(<App />);
+      });
+      userEvent.type(screen.getByLabelText("Start Date"), "2016-12-12");
+      expect(screen.getByLabelText("Start Date")).toHaveValue("2016-12-12");
       userEvent.type(screen.getByLabelText("End Date"), "2016-11-11");
       expect(screen.getByLabelText("End Date")).toHaveValue("2016-11-11");
       waitFor(() => {

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -211,13 +211,7 @@ describe("App", () => {
 
     it("automatically sets end date when start date is selected", async () => {
       mockCreateEntry.mockResolvedValue({});
-      mockGetEntries.mockResolvedValue([
-        {
-          end: "2022-02-27T05:43:37.868Z",
-          start: "2022-02-27T05:43:37.868Z",
-          title: "Berta goes to the baseball game!",
-        },
-      ]);
+      mockGetEntries.mockResolvedValue([]);
       await act(async () => {
         await render(<App />);
       });
@@ -228,13 +222,7 @@ describe("App", () => {
 
     it("errors when end date is before start date", async () => {
       mockCreateEntry.mockResolvedValue({});
-      mockGetEntries.mockResolvedValue([
-        {
-          end: "2022-02-27T05:43:37.868Z",
-          start: "2022-02-27T05:43:37.868Z",
-          title: "Berta goes to the baseball game!",
-        },
-      ]);
+      mockGetEntries.mockResolvedValue([]);
       await act(async () => {
         await render(<App />);
       });

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -223,6 +223,7 @@ describe("App", () => {
       });
       userEvent.type(screen.getByLabelText("Start Date"), "2016-12-12");
       expect(screen.getByLabelText("Start Date")).toHaveValue("2016-12-12");
+      expect(screen.getByLabelText("End Date")).toHaveValue("2016-12-12");
       userEvent.type(screen.getByLabelText("End Date"), "2016-11-11");
       expect(screen.getByLabelText("End Date")).toHaveValue("2016-11-11");
       waitFor(() => {

--- a/ui/src/EventForm.test.tsx
+++ b/ui/src/EventForm.test.tsx
@@ -164,31 +164,4 @@ describe("EventForm", () => {
     expect(screen.getByLabelText("End Time")).toHaveValue("05:00");
     expect(screen.getByLabelText("All Day")).not.toBeChecked();
   });
-
-  it.skip("automatically sets end date when start date is selected", () => {
-    render(
-      <EventForm
-        initialStartDate={formatDate(new Date())}
-        initialEndDate={formatDate(new Date())}
-        initialStartTime={`${padNumberWith0Zero(
-          currentHour
-        )}:${padNumberWith0Zero(currentMinute)}`}
-        initialEndTime={`${padNumberWith0Zero(
-          currentHour + 1
-        )}:${padNumberWith0Zero(currentMinute)}`}
-        initialTitle="Arty party"
-        initialDescription="A time to remember and appreciate classic art and more"
-        initialAllDay={false}
-        onFormSubmit={() => {}}
-        isCreate={true}
-      />
-    );
-    fireEvent.change(screen.getByLabelText("Start Date"), {
-      target: { value: "03162022" },
-    });
-    // userEvent.type(screen.getByLabelText("Start Date"), "03162022");
-
-    expect(screen.getByLabelText("Start Date")).toHaveValue("2022-03-16");
-    expect(screen.getByLabelText("End Date")).toHaveValue("2022-03-16");
-  });
 });

--- a/ui/src/EventForm.test.tsx
+++ b/ui/src/EventForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import React from "react";
 
 import userEvent from "@testing-library/user-event";
@@ -163,5 +163,32 @@ describe("EventForm", () => {
     expect(screen.getByLabelText("Start Time")).toHaveValue("04:00");
     expect(screen.getByLabelText("End Time")).toHaveValue("05:00");
     expect(screen.getByLabelText("All Day")).not.toBeChecked();
+  });
+
+  it.skip("automatically sets end date when start date is selected", () => {
+    render(
+      <EventForm
+        initialStartDate={formatDate(new Date())}
+        initialEndDate={formatDate(new Date())}
+        initialStartTime={`${padNumberWith0Zero(
+          currentHour
+        )}:${padNumberWith0Zero(currentMinute)}`}
+        initialEndTime={`${padNumberWith0Zero(
+          currentHour + 1
+        )}:${padNumberWith0Zero(currentMinute)}`}
+        initialTitle="Arty party"
+        initialDescription="A time to remember and appreciate classic art and more"
+        initialAllDay={false}
+        onFormSubmit={() => {}}
+        isCreate={true}
+      />
+    );
+    fireEvent.change(screen.getByLabelText("Start Date"), {
+      target: { value: "03162022" },
+    });
+    // userEvent.type(screen.getByLabelText("Start Date"), "03162022");
+
+    expect(screen.getByLabelText("Start Date")).toHaveValue("2022-03-16");
+    expect(screen.getByLabelText("End Date")).toHaveValue("2022-03-16");
   });
 });

--- a/ui/src/EventForm.test.tsx
+++ b/ui/src/EventForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 
 import userEvent from "@testing-library/user-event";

--- a/ui/src/EventForm.tsx
+++ b/ui/src/EventForm.tsx
@@ -98,7 +98,6 @@ const EventForm = ({
           min={formatDate(new Date())}
           type="date"
           onChange={(e) => {
-            console.log("event is", e.target.value);
             setStartDate(e.target.value);
             setEndDate(e.target.value);
           }}

--- a/ui/src/EventForm.tsx
+++ b/ui/src/EventForm.tsx
@@ -98,7 +98,9 @@ const EventForm = ({
           min={formatDate(new Date())}
           type="date"
           onChange={(e) => {
+            console.log("event is", e.target.value);
             setStartDate(e.target.value);
+            setEndDate(e.target.value);
           }}
           value={startDate}
         />

--- a/ui/src/__snapshots__/App.test.tsx.snap
+++ b/ui/src/__snapshots__/App.test.tsx.snap
@@ -14,7 +14,9 @@ exports[`App renders correctly 1`] = `
         <div
           class="form "
         >
-          <header>
+          <header
+            class="header"
+          >
             Create an event
           </header>
           <div
@@ -158,7 +160,7 @@ exports[`App renders correctly 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="chakra-icon css-k4htha"
+                class="chakra-icon css-bokek7"
                 focusable="false"
                 viewBox="0 0 24 24"
               >


### PR DESCRIPTION
_Closes:_ #61 

## Summary of changes
This PR updates the behavior of the form to update the end date to the same date as the start date once that's selected.

## Dev notes

## Testing

- [x] Unit tests

#### Screenshot of UI (local testing in browser)
