### PR TITLE
Cal 62 interactive calendar

### DIFF
--- a/e2e/cypress/e2e/spec.cy.js
+++ b/e2e/cypress/e2e/spec.cy.js
@@ -16,6 +16,7 @@ describe("journey test", () => {
       hostname: "localhost",
     }).as("createEntry");
 
+    cy.get(`[aria-label="add event"]`).click();
     cy.contains("label", "Title").click().type("Hello");
     cy.contains("label", "Description").click().type("It's a beautiful day");
     cy.contains("label", "Start Date").click().type("2022-11-26");
@@ -60,6 +61,7 @@ describe("journey test", () => {
       url: "/entries",
       hostname: "localhost",
     }).as("createEntry");
+    cy.get(`[aria-label="add event"]`).click();
     cy.contains("label", "Title").click().type("Bye");
     cy.contains("label", "Description").click().type("It's a beautiful night");
     cy.contains("label", "Start Date").click().type("2022-12-14");
@@ -75,6 +77,15 @@ describe("journey test", () => {
     cy.contains("Bye").should("be.visible");
     cy.contains("It's a beautiful night").should("be.visible");
     cy.findByText("Wednesday, December 14").should("exist");
-    cy.findByText("All Day").should("exist");
+    cy.findByText("all day").should("exist");
+  });
+
+  it("opens create event modal with date pre-selected when date is clicked", () => {
+    cy.visit("http://localhost:3000");
+    cy.get(`[data-date="2022-12-14"]`).click();
+    cy.get(".chakra-modal__body").within(() => {
+      cy.get(`[id="startDate"]`).should("have.value", "2022-12-14");
+      cy.get(`[id="endDate"]`).should("have.value", "2022-12-14");
+    });
   });
 });

--- a/e2e/cypress/e2e/spec.cy.js
+++ b/e2e/cypress/e2e/spec.cy.js
@@ -80,12 +80,26 @@ describe("journey test", () => {
     cy.findByText("all day").should("exist");
   });
 
-  it("opens create event modal with date pre-selected when date is clicked", () => {
+  it("opens create event modal with date, time, and all day pre-selected when field is clicked", () => {
     cy.visit("http://localhost:3000");
     cy.get(`[data-date="2022-12-14"]`).click();
     cy.get(".chakra-modal__body").within(() => {
       cy.get(`[id="startDate"]`).should("have.value", "2022-12-14");
       cy.get(`[id="endDate"]`).should("have.value", "2022-12-14");
+    });
+    cy.get(`[aria-label="Close"]`).click();
+    cy.findByText("week").click();
+    cy.get(`[data-date="2022-12-15"]`).eq(1).click();
+    cy.get(".chakra-modal__body").within(() => {
+      cy.get(`[id="startDate"]`).should("have.value", "2022-12-15");
+      cy.get(`[id="endDate"]`).should("have.value", "2022-12-15");
+      cy.get('[type="checkbox"]').should("be.checked");
+    });
+    cy.get(`[aria-label="Close"]`).click();
+    cy.get(`[data-time="06:30:00"]`).eq(1).click();
+    cy.get(".chakra-modal__body").within(() => {
+      cy.get(`[id="startTime"]`).should("have.value", "06:30");
+      cy.get(`[id="endTime"]`).should("have.value", "07:30");
     });
   });
 });

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -27,6 +27,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@fullcalendar/interaction": "^5.11.3",
         "@types/jest": "^29.2.0",
         "ts-jest": "^29.0.3",
         "ts-node": "^10.9.1",
@@ -3528,6 +3529,16 @@
       "version": "5.11.3",
       "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-5.11.3.tgz",
       "integrity": "sha512-PCK0y80DRNCzWuC5lGpIWqCgKDvql1ah7rXql5lu+Gn2EeFj15ZQ8diMFjtNIQucEmFaNOXnR05Pgcry1n6Shg==",
+      "dependencies": {
+        "@fullcalendar/common": "~5.11.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@fullcalendar/interaction": {
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-5.11.3.tgz",
+      "integrity": "sha512-L955wkDjza62K96ndstvYs2Fd4V0kayTDpqW8W7huFG3Ox8MutpLqKAa2SCaTvcNIlWS4oexGQRiQAaJG7u47A==",
+      "dev": true,
       "dependencies": {
         "@fullcalendar/common": "~5.11.3",
         "tslib": "^2.1.0"
@@ -24672,6 +24683,16 @@
       "version": "5.11.3",
       "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-5.11.3.tgz",
       "integrity": "sha512-PCK0y80DRNCzWuC5lGpIWqCgKDvql1ah7rXql5lu+Gn2EeFj15ZQ8diMFjtNIQucEmFaNOXnR05Pgcry1n6Shg==",
+      "requires": {
+        "@fullcalendar/common": "~5.11.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@fullcalendar/interaction": {
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-5.11.3.tgz",
+      "integrity": "sha512-L955wkDjza62K96ndstvYs2Fd4V0kayTDpqW8W7huFG3Ox8MutpLqKAa2SCaTvcNIlWS4oexGQRiQAaJG7u47A==",
+      "dev": true,
       "requires": {
         "@fullcalendar/common": "~5.11.3",
         "tslib": "^2.1.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -49,6 +49,7 @@
     ]
   },
   "devDependencies": {
+    "@fullcalendar/interaction": "^5.11.3",
     "@types/jest": "^29.2.0",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",

--- a/ui/src/App.module.css
+++ b/ui/src/App.module.css
@@ -21,6 +21,7 @@
 
 .leftSidePanel {
   display: flex;
+  margin: 10px;
   width: 15vw;
 }
 

--- a/ui/src/App.module.css
+++ b/ui/src/App.module.css
@@ -19,6 +19,11 @@
   padding-left: 20px;
 }
 
+.leftSidePanel {
+  display: flex;
+  width: 15vw;
+}
+
 .addEventButton {
   display: none;
 }
@@ -34,9 +39,8 @@
 
 .form {
   align-items: center;
-  display: flex;
+  display: none;
   flex-direction: column;
-  width: 25vw;
 }
 
 .fullCalendarUI {
@@ -48,6 +52,30 @@
   margin: 10px;
 }
 
+.active {
+  background-color: white;
+  bottom: 0;
+  display: block;
+  left: 0;
+  padding-top: 20px;
+  position: fixed;
+  right: 0;
+  top: 0;
+  width: 100%;
+  z-index: 2;
+}
+
+.closeButton {
+  display: block;
+  position: absolute;
+  right: 20px;
+  top: 20px;
+}
+
+.buttonText {
+  display: block;
+}
+
 @media (max-width: 600px) {
   .addEventButton {
     display: block;
@@ -57,26 +85,12 @@
     top: 9px;
   }
 
-  .form {
-    display: none;
-  }
-
-  .header {
+  .createEventButton {
     display: flex;
     justify-content: center;
-  }
-
-  .active {
-    background-color: white;
-    bottom: 0;
-    display: block;
-    left: 0;
-    padding-top: 20px;
-    position: fixed;
-    right: 0;
-    top: 0;
-    width: 100%;
-    z-index: 2;
+    background: rgb(157, 156, 156);
+    height: 50px;
+    width: 100px;
   }
 
   .fullCalendarUI {
@@ -86,10 +100,7 @@
     width: 100%;
   }
 
-  .closeButton {
-    display: block;
-    position: absolute;
-    right: 20px;
-    top: 20px;
+  .buttonText {
+    display: none;
   }
 }

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -216,6 +216,7 @@ describe("App", () => {
       await act(async () => {
         await render(<App />);
       });
+      userEvent.click(screen.getByLabelText("add event"));
       userEvent.type(screen.getByLabelText("Start Date"), "2016-12-12");
       expect(screen.getByLabelText("Start Date")).toHaveValue("2016-12-12");
       expect(screen.getByLabelText("End Date")).toHaveValue("2016-12-12");
@@ -236,8 +237,8 @@ describe("App", () => {
         userEvent.click(screen.getByRole("button", { name: "Create Event" }));
       });
       expect(
-        screen.getByText("Error: end cannot be before start."),
-      ).toBeVisible();
+        screen.getByText("Error: end cannot be before start.")
+      ).toBeInTheDocument();
     });
 
     it("errors when end time is before start time on the same day", async () => {
@@ -257,8 +258,8 @@ describe("App", () => {
         userEvent.click(screen.getByRole("button", { name: "Create Event" }));
       });
       expect(
-        screen.getByText("Error: end cannot be before start."),
-      ).toBeVisible();
+        screen.getByText("Error: end cannot be before start.")
+      ).toBeInTheDocument();
     });
   });
 });

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -67,6 +67,7 @@ describe("App", () => {
       waitFor(() => {
         render(<App />);
       });
+      userEvent.click(screen.getByLabelText("add event"));
       expect(screen.getByLabelText("Start Date")).toHaveValue("2022-02-15");
       expect(screen.getByLabelText("End Date")).toHaveValue("2022-02-15");
       expect(screen.getByLabelText("Start Time")).toHaveValue("04:00");
@@ -87,6 +88,7 @@ describe("App", () => {
         await render(<App />);
       });
       expect(mockGetEntries).toHaveBeenCalledTimes(1);
+      userEvent.click(screen.getByLabelText("add event"));
       userEvent.click(screen.getByLabelText("Title"));
       userEvent.type(
         screen.getByLabelText("Title"),
@@ -225,6 +227,7 @@ describe("App", () => {
       await act(async () => {
         await render(<App />);
       });
+      userEvent.click(screen.getByLabelText("add event"));
       userEvent.type(screen.getByLabelText("Start Date"), "2016-12-12");
       expect(screen.getByLabelText("Start Date")).toHaveValue("2016-12-12");
       userEvent.type(screen.getByLabelText("End Date"), "2016-11-11");
@@ -243,6 +246,7 @@ describe("App", () => {
       await act(async () => {
         await render(<App />);
       });
+      userEvent.click(screen.getByLabelText("add event"));
       expect(screen.getByLabelText("Start Date")).toHaveValue("2022-02-15");
       expect(screen.getByLabelText("End Date")).toHaveValue("2022-02-15");
       userEvent.type(screen.getByLabelText("Start Time"), "12:00");

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -222,8 +222,7 @@ const App = () => {
           <ModalOverlay />
           <ModalContent>
             <ModalHeader>
-              <p className={s.title}>{displayedEventData.title}</p>
-              {inCreateMode ? "Create an Event" : "Event Details"}
+              {inCreateMode ? "Create an Event" : displayedEventData.title}
             </ModalHeader>
             <ModalCloseButton />
             {!inEditMode && !inCreateMode && (

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -11,6 +11,7 @@ import {
   padNumberWith0Zero,
   formatTime,
   modalDateFormat,
+  oneHourLater,
 } from "./lib";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
@@ -81,6 +82,10 @@ const App = () => {
   const [inEditMode, setInEditMode] = useState<boolean>(false);
   const [inCreateMode, setInCreateMode] = useState<boolean>(false);
   const [modalDate, setModalDate] = useState<string>(DEFAULT_DATE);
+  const [modalStartTime, setModalStartTime] =
+    useState<string>(DEFAULT_START_TIME);
+  const [modalEndTime, setModalEndTime] = useState<string>(DEFAULT_END_TIME);
+  const [modalAllDay, setModalAllDay] = useState<boolean>(false);
 
   useEffect(() => {
     getEntries().then((entries) => {
@@ -204,7 +209,15 @@ const App = () => {
                 eventClick={openModal}
                 height="100vh"
                 dateClick={(DateClickObject) => {
+                  console.log("from date click", DateClickObject);
                   setModalDate(formatDate(DateClickObject.date));
+                  setModalStartTime(
+                    formatTime(DateClickObject.date.toUTCString())
+                  );
+                  setModalEndTime(
+                    oneHourLater(DateClickObject.date.toUTCString())
+                  );
+                  setModalAllDay(DateClickObject.allDay);
                   setInCreateMode(true);
                   setShowOverlay(true);
                 }}
@@ -279,9 +292,9 @@ const App = () => {
                   initialDescription=""
                   initialStartDate={modalDate}
                   initialEndDate={modalDate}
-                  initialStartTime={DEFAULT_START_TIME}
-                  initialEndTime={DEFAULT_END_TIME}
-                  initialAllDay={false}
+                  initialStartTime={modalStartTime}
+                  initialEndTime={modalEndTime}
+                  initialAllDay={modalAllDay}
                   onFormSubmit={handleCreateEntry}
                   isCreate={true}
                 />

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -185,6 +185,8 @@ const App = () => {
                 icon={<AddIcon boxSize={5} w={5} h={5} />}
                 onClick={() => {
                   setModalDate(DEFAULT_DATE);
+                  setModalStartTime(DEFAULT_START_TIME);
+                  setModalEndTime(DEFAULT_END_TIME);
                   setInCreateMode(true);
                   setShowOverlay(true);
                 }}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -211,7 +211,6 @@ const App = () => {
                 eventClick={openModal}
                 height="100vh"
                 dateClick={(DateClickObject) => {
-                  console.log("from date click", DateClickObject);
                   setModalDate(formatDate(DateClickObject.date));
                   setModalStartTime(
                     formatTime(DateClickObject.date.toUTCString())

--- a/ui/src/EventForm.test.tsx
+++ b/ui/src/EventForm.test.tsx
@@ -131,37 +131,4 @@ describe("EventForm", () => {
     expect(screen.getByLabelText("Start Time")).toBeInTheDocument();
     expect(screen.getByLabelText("End Time")).toBeInTheDocument();
   });
-
-  it("resets inputs correctly to default values when submitted", async () => {
-    render(
-      <EventForm
-        initialStartDate={formatDate(new Date())}
-        initialEndDate={formatDate(new Date())}
-        initialStartTime={`${padNumberWith0Zero(
-          currentHour,
-        )}:${padNumberWith0Zero(currentMinute)}`}
-        initialEndTime={`${padNumberWith0Zero(
-          currentHour + 1,
-        )}:${padNumberWith0Zero(currentMinute)}`}
-        initialTitle="Arty party"
-        initialDescription="A time to remember and appreciate classic art and more"
-        initialAllDay={false}
-        onFormSubmit={() => {}}
-        isCreate={true}
-      />,
-    );
-    userEvent.type(screen.getByLabelText("Start Date"), "03162022");
-    userEvent.type(screen.getByLabelText("Start Time"), "08:10");
-    userEvent.type(screen.getByLabelText("End Date"), "03182022");
-    userEvent.type(screen.getByLabelText("End Time"), "10:10");
-    userEvent.click(screen.getByLabelText("All Day"));
-    await waitFor(() => {
-      userEvent.click(screen.getByRole("button", { name: "Create Event" }));
-    });
-    expect(screen.getByLabelText("Start Date")).toHaveValue("");
-    expect(screen.getByLabelText("End Date")).toHaveValue("");
-    expect(screen.getByLabelText("Start Time")).toHaveValue("");
-    expect(screen.getByLabelText("End Time")).toHaveValue("");
-    expect(screen.getByLabelText("All Day")).not.toBeChecked();
-  });
 });

--- a/ui/src/EventForm.tsx
+++ b/ui/src/EventForm.tsx
@@ -51,17 +51,6 @@ const EventForm = ({
       endTime,
       allDay,
     });
-
-    if (isCreate) {
-      setTitle(initialTitle);
-      setDescription(initialDescription);
-      setError(null);
-      setStartDate("");
-      setEndDate("");
-      setStartTime("");
-      setEndTime("");
-      setAllDay(initialAllDay);
-    }
   };
 
   return (

--- a/ui/src/__snapshots__/App.test.tsx.snap
+++ b/ui/src/__snapshots__/App.test.tsx.snap
@@ -14,13 +14,10 @@ exports[`App renders correctly 1`] = `
         <div
           class="leftSidePanel"
         >
-          <header
-            class="header"
-          >
-            Create an event
-          </header>
-          <div
-            class="closeButton"
+          <button
+            aria-label="add event"
+            class="chakra-button css-eeqq40"
+            type="button"
           >
             <svg
               aria-hidden="true"
@@ -38,27 +35,6 @@ exports[`App renders correctly 1`] = `
         <div
           class="fullCalendarUI"
         >
-          <div
-            class="addEventButton"
-          >
-            <button
-              aria-label="add event"
-              class="chakra-button css-eeqq40"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="chakra-icon css-bokek7"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M0,12a1.5,1.5,0,0,0,1.5,1.5h8.75a.25.25,0,0,1,.25.25V22.5a1.5,1.5,0,0,0,3,0V13.75a.25.25,0,0,1,.25-.25H22.5a1.5,1.5,0,0,0,0-3H13.75a.25.25,0,0,1-.25-.25V1.5a1.5,1.5,0,0,0-3,0v8.75a.25.25,0,0,1-.25.25H1.5A1.5,1.5,0,0,0,0,12Z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
-          </div>
           <div
             class="fc fc-media-screen fc-direction-ltr fc-theme-standard fc-liquid-hack"
             style="height: 100vh;"

--- a/ui/src/__snapshots__/App.test.tsx.snap
+++ b/ui/src/__snapshots__/App.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`App renders correctly 1`] = `
         class="mainContainer"
       >
         <div
-          class="form "
+          class="leftSidePanel"
         >
           <header
             class="header"
@@ -22,130 +22,18 @@ exports[`App renders correctly 1`] = `
           <div
             class="closeButton"
           >
-            <button
-              aria-label="Close"
-              class="css-4abrhy"
-              type="button"
+            <svg
+              aria-hidden="true"
+              class="chakra-icon css-bokek7"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              <svg
-                aria-hidden="true"
-                class="chakra-icon css-onkibi"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M.439,21.44a1.5,1.5,0,0,0,2.122,2.121L11.823,14.3a.25.25,0,0,1,.354,0l9.262,9.263a1.5,1.5,0,1,0,2.122-2.121L14.3,12.177a.25.25,0,0,1,0-.354l9.263-9.262A1.5,1.5,0,0,0,21.439.44L12.177,9.7a.25.25,0,0,1-.354,0L2.561.44A1.5,1.5,0,0,0,.439,2.561L9.7,11.823a.25.25,0,0,1,0,.354Z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="container"
-          >
-            <label
-              class="formItem"
-              for="title"
-            >
-              Title
-              <input
-                class="formInput"
-                id="title"
-                type="text"
-                value=""
+              <path
+                d="M0,12a1.5,1.5,0,0,0,1.5,1.5h8.75a.25.25,0,0,1,.25.25V22.5a1.5,1.5,0,0,0,3,0V13.75a.25.25,0,0,1,.25-.25H22.5a1.5,1.5,0,0,0,0-3H13.75a.25.25,0,0,1-.25-.25V1.5a1.5,1.5,0,0,0-3,0v8.75a.25.25,0,0,1-.25.25H1.5A1.5,1.5,0,0,0,0,12Z"
+                fill="currentColor"
               />
-            </label>
-            <label
-              class="formItem"
-              for="description"
-            >
-              Description
-              <input
-                class="formInput"
-                id="description"
-                type="text"
-                value=""
-              />
-            </label>
-            <label
-              class="formItem"
-              for="startDate"
-            >
-              Start Date
-              <input
-                class="formInput"
-                id="startDate"
-                min="2022-02-15"
-                type="date"
-                value="2022-02-15"
-              />
-            </label>
-            <label
-              class="formItem"
-              for="endDate"
-            >
-              End Date
-              <input
-                class="formInput"
-                id="endDate"
-                min="2022-02-15"
-                type="date"
-                value="2022-02-15"
-              />
-            </label>
-            <div
-              class="checkbox"
-            >
-              <label
-                class="chakra-checkbox css-1577qb8"
-              >
-                <input
-                  class="chakra-checkbox__input"
-                  style="border: 0px; clip: rect(0px, 0px, 0px, 0px); height: 1px; width: 1px; margin: -1px; padding: 0px; overflow: hidden; white-space: nowrap; position: absolute;"
-                  type="checkbox"
-                  value=""
-                />
-                <span
-                  aria-hidden="true"
-                  class="chakra-checkbox__control css-1ydjfm6"
-                />
-                <span
-                  class="chakra-checkbox__label css-6x44c9"
-                >
-                  All Day
-                </span>
-              </label>
-            </div>
-            <label
-              class="formItem"
-              for="startTime"
-            >
-              Start Time
-              <input
-                class="formInput"
-                id="startTime"
-                type="time"
-                value="04:00"
-              />
-            </label>
-            <label
-              class="formItem"
-              for="endTime"
-            >
-              End Time
-              <input
-                class="formInput"
-                id="endTime"
-                type="time"
-                value="05:00"
-              />
-            </label>
-            <button
-              class="formSubmit"
-            >
-              Create Event
-            </button>
-          </div>
+            </svg>
+          </button>
         </div>
         <div
           class="fullCalendarUI"

--- a/ui/src/lib.ts
+++ b/ui/src/lib.ts
@@ -56,6 +56,11 @@ const formatTime = (utcString: string) =>
     new Date(utcString).getMinutes()
   )}`;
 
+const oneHourLater = (utcString: string) =>
+  `${padNumberWith0Zero(
+    new Date(utcString).getHours() + 1
+  )}:${padNumberWith0Zero(new Date(utcString).getMinutes())}`;
+
 export {
   formatDate,
   getDateTimeString,
@@ -64,4 +69,5 @@ export {
   formatTime,
   dateFormat,
   timeFormat,
+  oneHourLater,
 };


### PR DESCRIPTION
_Closes:_ #64 

## Summary of changes
This PR implements the interactive calendar and allows for opening the modal by clicking a date or time slot, or an all day slot from the week or day views. The modal will then be pre-filled with the correct date, time and allDay values.

This behavior is testing via Cypress as selecting the FullCalendar elements proved challenging in unit tests.

## Dev notes

## Testing

- [ ] Unit tests

#### Screenshot of UI (local testing in browser)
