### PR TITLE
Fix all day short display bug

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,6 +1,5 @@
 import React, { MouseEvent, useEffect } from "react";
 import EventForm from "./EventForm";
-import moment from "moment";
 import { useState } from "react";
 import FullCalendar, {
   EventClickArg,
@@ -13,6 +12,7 @@ import {
   formatTime,
   modalDateFormat,
   oneHourLater,
+  addDayToAllDayEvent,
 } from "./lib";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
@@ -223,12 +223,7 @@ const App = () => {
                   setInCreateMode(true);
                   setShowOverlay(true);
                 }}
-                eventDataTransform={(event) => {
-                  if (event.allDay) {
-                    event.end = moment(event.end).add(1, "days").toDate();
-                  }
-                  return event;
-                }}
+                eventDataTransform={addDayToAllDayEvent}
                 // editable={true}
                 // selectMirror={true}
                 // dayMaxEvents={true}
@@ -241,12 +236,10 @@ const App = () => {
         <Modal isOpen={showOverlay} onClose={closeOverlay}>
           <ModalOverlay />
           <ModalContent>
-            <ModalHeader>
-              {inCreateMode ? "Create an Event" : displayedEventData.title}
-            </ModalHeader>
-            <ModalCloseButton />
             {!inEditMode && !inCreateMode && (
               <>
+                <ModalHeader>{displayedEventData.title}</ModalHeader>
+                <ModalCloseButton />
                 <ModalBody>
                   <div className={s.eventDetails}>
                     <p>{displayedEventData.description}</p>
@@ -274,38 +267,48 @@ const App = () => {
               </>
             )}
             {inEditMode && (
-              <ModalBody>
-                <EventForm
-                  initialTitle={displayedEventData.title}
-                  initialDescription={displayedEventData.description}
-                  initialStartDate={formatDate(
-                    new Date(displayedEventData.startTimeUtc)
-                  )}
-                  initialEndDate={formatDate(
-                    new Date(displayedEventData.endTimeUtc)
-                  )}
-                  initialStartTime={formatTime(displayedEventData.startTimeUtc)}
-                  initialEndTime={formatTime(displayedEventData.endTimeUtc)}
-                  initialAllDay={displayedEventData.allDay}
-                  onFormSubmit={handleSaveChanges}
-                  isCreate={false}
-                />
-              </ModalBody>
+              <>
+                <ModalHeader>Edit event</ModalHeader>
+                <ModalCloseButton />
+                <ModalBody>
+                  <EventForm
+                    initialTitle={displayedEventData.title}
+                    initialDescription={displayedEventData.description}
+                    initialStartDate={formatDate(
+                      new Date(displayedEventData.startTimeUtc)
+                    )}
+                    initialEndDate={formatDate(
+                      new Date(displayedEventData.endTimeUtc)
+                    )}
+                    initialStartTime={formatTime(
+                      displayedEventData.startTimeUtc
+                    )}
+                    initialEndTime={formatTime(displayedEventData.endTimeUtc)}
+                    initialAllDay={displayedEventData.allDay}
+                    onFormSubmit={handleSaveChanges}
+                    isCreate={false}
+                  />
+                </ModalBody>
+              </>
             )}
             {inCreateMode && (
-              <ModalBody>
-                <EventForm
-                  initialTitle=""
-                  initialDescription=""
-                  initialStartDate={modalDate}
-                  initialEndDate={modalDate}
-                  initialStartTime={modalStartTime}
-                  initialEndTime={modalEndTime}
-                  initialAllDay={modalAllDay}
-                  onFormSubmit={handleCreateEntry}
-                  isCreate={true}
-                />
-              </ModalBody>
+              <>
+                <ModalHeader>Create event</ModalHeader>
+                <ModalCloseButton />
+                <ModalBody>
+                  <EventForm
+                    initialTitle=""
+                    initialDescription=""
+                    initialStartDate={modalDate}
+                    initialEndDate={modalDate}
+                    initialStartTime={modalStartTime}
+                    initialEndTime={modalEndTime}
+                    initialAllDay={modalAllDay}
+                    onFormSubmit={handleCreateEntry}
+                    isCreate={true}
+                  />
+                </ModalBody>
+              </>
             )}
           </ModalContent>
         </Modal>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { MouseEvent, useEffect } from "react";
 import EventForm from "./EventForm";
+import moment from "moment";
 import { useState } from "react";
 import FullCalendar, {
   EventClickArg,
@@ -222,7 +223,12 @@ const App = () => {
                   setInCreateMode(true);
                   setShowOverlay(true);
                 }}
-
+                eventDataTransform={(event) => {
+                  if (event.allDay) {
+                    event.end = moment(event.end).add(1, "days").toDate();
+                  }
+                  return event;
+                }}
                 // editable={true}
                 // selectMirror={true}
                 // dayMaxEvents={true}

--- a/ui/src/lib.test.ts
+++ b/ui/src/lib.test.ts
@@ -1,41 +1,54 @@
-import { modalDateFormat } from "./lib";
+import { addDayToAllDayEvent, modalDateFormat } from "./lib";
 
-describe("modalDateFormat", () => {
-  it("returns two dates seperated by a dash for all day events", () => {
-    const result = modalDateFormat({
-      startTimeUtc: "2022-12-11T14:43:37.868Z",
-      endTimeUtc: "2022-12-14T14:43:37.868Z",
-      allDay: true,
+describe("lib functions", () => {
+  describe("modalDateFormat", () => {
+    it("returns two dates seperated by a dash for all day events", () => {
+      const result = modalDateFormat({
+        startTimeUtc: "2022-12-11T14:43:37.868Z",
+        endTimeUtc: "2022-12-14T14:43:37.868Z",
+        allDay: true,
+      });
+      expect(result).toEqual("Sunday, December 11 - Wednesday, December 14");
     });
-    expect(result).toEqual("Sunday, December 11 - Wednesday, December 14");
+
+    it("returns single date when an all day same day event", () => {
+      const result = modalDateFormat({
+        startTimeUtc: "2022-12-11T14:43:37.868Z",
+        endTimeUtc: "2022-12-11T14:45:37.868Z",
+        allDay: true,
+      });
+      expect(result).toEqual("Sunday, December 11");
+    });
+
+    it("returns one day with dashed times for same day events", () => {
+      const result = modalDateFormat({
+        startTimeUtc: "2022-12-11T14:43:37.868Z",
+        endTimeUtc: "2022-12-11T16:45:37.868Z",
+        allDay: false,
+      });
+      expect(result).toEqual("Sunday, December 11 06:43 AM - 08:45 AM");
+    });
+
+    it("returns days and times with dash in between for different day events", () => {
+      const result = modalDateFormat({
+        startTimeUtc: "2022-12-11T14:43:37.868Z",
+        endTimeUtc: "2022-12-14T16:45:37.868Z",
+        allDay: false,
+      });
+      expect(result).toEqual(
+        "Sunday, December 11 06:43 AM - Wednesday, December 14 08:45 AM"
+      );
+    });
   });
 
-  it("returns single date when an all day same day event", () => {
-    const result = modalDateFormat({
-      startTimeUtc: "2022-12-11T14:43:37.868Z",
-      endTimeUtc: "2022-12-11T14:45:37.868Z",
-      allDay: true,
+  describe("addDayToAllDayEvent", () => {
+    it("adds one day to all day end dates", () => {
+      const event = {
+        allDay: true,
+        end: new Date("2022-02-15T04:00"),
+      };
+      const updatedEvent = addDayToAllDayEvent(event);
+      expect(updatedEvent.end).toEqual(new Date("2022-02-16T04:00"));
     });
-    expect(result).toEqual("Sunday, December 11");
-  });
-
-  it("returns one day with dashed times for same day events", () => {
-    const result = modalDateFormat({
-      startTimeUtc: "2022-12-11T14:43:37.868Z",
-      endTimeUtc: "2022-12-11T16:45:37.868Z",
-      allDay: false,
-    });
-    expect(result).toEqual("Sunday, December 11 06:43 AM - 08:45 AM");
-  });
-
-  it("returns days and times with dash in between for different day events", () => {
-    const result = modalDateFormat({
-      startTimeUtc: "2022-12-11T14:43:37.868Z",
-      endTimeUtc: "2022-12-14T16:45:37.868Z",
-      allDay: false,
-    });
-    expect(result).toEqual(
-      "Sunday, December 11 06:43 AM - Wednesday, December 14 08:45 AM"
-    );
   });
 });

--- a/ui/src/lib.test.ts
+++ b/ui/src/lib.test.ts
@@ -42,13 +42,22 @@ describe("lib functions", () => {
   });
 
   describe("addDayToAllDayEvent", () => {
-    it("adds one day to all day end dates", () => {
+    it("adds one day end date of all day events", () => {
       const event = {
         allDay: true,
         end: new Date("2022-02-15T04:00"),
       };
       const updatedEvent = addDayToAllDayEvent(event);
       expect(updatedEvent.end).toEqual(new Date("2022-02-16T04:00"));
+    });
+
+    it("does not modify dates when event is not all day", () => {
+      const event = {
+        allDay: false,
+        end: new Date("2022-02-15T04:00"),
+      };
+      const updatedEvent = addDayToAllDayEvent(event);
+      expect(updatedEvent.end).toEqual(new Date("2022-02-15T04:00"));
     });
   });
 });

--- a/ui/src/lib.ts
+++ b/ui/src/lib.ts
@@ -1,3 +1,6 @@
+import moment from "moment";
+import { EventInputTransformer, EventInput } from "@fullcalendar/react";
+
 const padNumberWith0Zero: Function = (num: Number): string =>
   num.toString().padStart(2, "0");
 
@@ -61,7 +64,15 @@ const oneHourLater = (utcString: string) =>
     new Date(utcString).getHours() + 1
   )}:${padNumberWith0Zero(new Date(utcString).getMinutes())}`;
 
+const addDayToAllDayEvent: EventInputTransformer = (event: EventInput) => {
+  if (event.allDay) {
+    event.end = moment(event.end).add(1, "days").toDate();
+  }
+  return event;
+};
+
 export {
+  addDayToAllDayEvent,
   formatDate,
   getDateTimeString,
   padNumberWith0Zero,


### PR DESCRIPTION
_Closes:_ #70 

## Summary of changes
This change fixes the issue where all day events display one day short. Fix based on this StackOverflow question: https://stackoverflow.com/questions/27604359/fullcalendar-event-spanning-all-day-are-one-day-too-short

## Dev notes

## Testing

- [x] Unit tests

#### Screenshot of UI (local testing in browser)
