### PR TITLE
Disallow form submission with empty title

### DIFF
--- a/ui/src/EventForm.test.tsx
+++ b/ui/src/EventForm.test.tsx
@@ -124,7 +124,7 @@ describe("EventForm", () => {
       />
     );
     userEvent.click(screen.getByRole("button"));
-    expect(screen.getByText("Error: title cannot be empty.")).toBeInTheDocument;
+    expect(screen.getByText("Error: title cannot be empty.")).toBeVisible();
   });
 
   it("hides time sections when all day is selected", () => {

--- a/ui/src/EventForm.test.tsx
+++ b/ui/src/EventForm.test.tsx
@@ -104,6 +104,29 @@ describe("EventForm", () => {
     });
   });
 
+  it("displays error when form is submitted with no title", () => {
+    const onFormSubmitMock = jest.fn();
+    render(
+      <EventForm
+        initialStartDate={formatDate(new Date())}
+        initialEndDate={formatDate(new Date())}
+        initialStartTime={`${padNumberWith0Zero(
+          currentHour
+        )}:${padNumberWith0Zero(currentMinute)}`}
+        initialEndTime={`${padNumberWith0Zero(
+          currentHour + 1
+        )}:${padNumberWith0Zero(currentMinute)}`}
+        initialTitle=""
+        initialDescription="A time to remember and appreciate classic art and more"
+        initialAllDay={false}
+        onFormSubmit={onFormSubmitMock}
+        isCreate={false}
+      />
+    );
+    userEvent.click(screen.getByRole("button"));
+    expect(screen.getByText("Error: title cannot be empty.")).toBeInTheDocument;
+  });
+
   it("hides time sections when all day is selected", () => {
     render(
       <EventForm

--- a/ui/src/EventForm.tsx
+++ b/ui/src/EventForm.tsx
@@ -38,6 +38,10 @@ const EventForm = ({
   const handleFormSubmit = async (_: React.MouseEvent<HTMLButtonElement>) => {
     const startDateAndTime: string = getDateTimeString(startDate, startTime);
     const endDateAndTime: string = getDateTimeString(endDate, endTime);
+    if (title === "") {
+      setError("Error: title cannot be empty.");
+      return;
+    }
     if (startDateAndTime > endDateAndTime) {
       setError("Error: end cannot be before start.");
       return;


### PR DESCRIPTION
_Closes:_ #73 

## Summary of changes
This PR prevents submitting the event form without a title. If the user attempts to do so, they will see an error stating that the title cannot be empty,

## Dev notes

## Testing

- [x] Unit tests

#### Screenshot of UI (local testing in browser)
