### PR TITLE
Cal 53 Front end error handling

### DIFF
--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -102,8 +102,10 @@ describe("App", () => {
       userEvent.type(screen.getByLabelText("Start Time"), "08:10");
       userEvent.type(screen.getByLabelText("End Date"), "02152022");
       userEvent.type(screen.getByLabelText("End Time"), "10:10");
-      await waitFor(() => {
-        userEvent.click(screen.getByRole("button", { name: "Create Event" }));
+      await act(async () => {
+        await waitFor(() => {
+          userEvent.click(screen.getByRole("button", { name: "Create Event" }));
+        });
       });
       expect(await screen.findByLabelText("Title")).toHaveAttribute(
         "value",

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -258,8 +258,20 @@ describe("App", () => {
         userEvent.click(screen.getByRole("button", { name: "Create Event" }));
       });
       expect(
-        screen.getByText("Error: end cannot be before start.")
+        screen.getByText("Error: end cannot be before start."),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("errors", () => {
+    it("getEntries error displays error message", () => {
+      mockGetEntries.mockRejectedValue("Error in getEntry");
+      waitFor(() => {
+        act(() => {
+          render(<App />);
+        });
+      });
+      expect(screen.getByRole("alert")).toBeVisible();
     });
   });
 });

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -107,7 +107,7 @@ describe("App", () => {
       });
       expect(await screen.findByLabelText("Title")).toHaveAttribute(
         "value",
-        "",
+        "Berta goes to the baseball game!",
       );
       expect(
         await screen.findByText("Berta goes to the baseball game!"),
@@ -237,7 +237,7 @@ describe("App", () => {
         userEvent.click(screen.getByRole("button", { name: "Create Event" }));
       });
       expect(
-        screen.getByText("Error: end cannot be before start.")
+        screen.getByText("Error: end cannot be before start."),
       ).toBeInTheDocument();
     });
 

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -23,13 +23,7 @@ describe("App", () => {
 
   it("renders correctly", async () => {
     mockCreateEntry.mockResolvedValue({});
-    mockGetEntries.mockResolvedValue([
-      {
-        end: "2022-02-27T05:43:37.868Z",
-        start: "2022-02-27T05:43:37.868Z",
-        title: "Berta goes to the baseball game!",
-      },
-    ]);
+    mockGetEntries.mockResolvedValue([]);
     const app: any = render(<App />);
     expect(await screen.findByText(/Mon/)).toBeVisible();
     expect(app.asFragment()).toMatchSnapshot();
@@ -268,11 +262,36 @@ describe("App", () => {
   describe("errors", () => {
     it("getEntries error displays error message", async () => {
       mockGetEntries.mockRejectedValue("Error in getEntry");
-      waitFor(() => {
-        act(() => {
-          render(<App />);
-        });
+      await act(async () => {
+        await render(<App />);
       });
+      expect(await screen.findByRole("alert")).toBeVisible();
+    });
+
+    it("createEntry error displays error message", async () => {
+      mockGetEntries.mockResolvedValue([]);
+      mockCreateEntry.mockRejectedValue("Error in createEntry");
+      await act(async () => {
+        await render(<App />);
+      });
+      userEvent.click(screen.getByLabelText("add event"));
+      userEvent.click(screen.getByLabelText("Title"));
+      userEvent.type(
+        screen.getByLabelText("Title"),
+        "Berta goes to the baseball game!",
+      );
+      userEvent.type(
+        screen.getByLabelText("Description"),
+        "She had some tasty nachos and margaritas!",
+      );
+      userEvent.type(screen.getByLabelText("Start Date"), "02152022");
+      userEvent.type(screen.getByLabelText("Start Time"), "08:10");
+      userEvent.type(screen.getByLabelText("End Date"), "02152022");
+      userEvent.type(screen.getByLabelText("End Time"), "10:10");
+      await act(async () => {
+        userEvent.click(screen.getByRole("button", { name: "Create Event" }));
+      });
+
       expect(await screen.findByRole("alert")).toBeVisible();
     });
   });

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -327,7 +327,7 @@ describe("App", () => {
       expect(await screen.findByRole("alert")).toBeVisible();
     });
 
-    it.skip("updateEntry displays an error message", async () => {
+    it("updateEntry displays an error message", async () => {
       mockGetEntries.mockResolvedValueOnce([
         {
           _id: "123",
@@ -356,24 +356,11 @@ describe("App", () => {
         await eventText.click();
       });
 
-      const editText = await screen.findByText("Edit");
-      expect(editText).toBeInTheDocument();
-
-      // userEvent.click(screen.getByText("Edit"));
-
-      const editButton = await screen.findByText("Edit");
-      await act(async () => {
-        await editButton.click();
-      });
-
-      expect(screen.getByLabelText("Description")).toBeVisible();
+      userEvent.click(screen.getByText("Edit"));
       userEvent.type(
         screen.getByLabelText("Description"),
         "party in the evening"
       );
-
-      const descriptionText = await screen.findByText("party in the evening");
-      expect(descriptionText).toBeInTheDocument();
 
       userEvent.click(screen.getByText("Save"));
       expect(await screen.findByRole("alert")).toBeVisible();

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -264,14 +264,14 @@ describe("App", () => {
   });
 
   describe("errors", () => {
-    it("getEntries error displays error message", () => {
+    it("getEntries error displays error message", async () => {
       mockGetEntries.mockRejectedValue("Error in getEntry");
       waitFor(() => {
         act(() => {
           render(<App />);
         });
       });
-      expect(screen.getByRole("alert")).toBeVisible();
+      expect(await screen.findByRole("alert")).toBeVisible();
     });
   });
 });

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -73,15 +73,15 @@ const App = () => {
   const currentHour: number = new Date().getHours();
   const currentMinute: number = new Date().getMinutes();
   const DEFAULT_START_TIME: string = `${padNumberWith0Zero(
-    currentHour,
+    currentHour
   )}:${padNumberWith0Zero(currentMinute)}`;
   const DEFAULT_END_TIME: string = `${padNumberWith0Zero(
-    currentHour + 1,
+    currentHour + 1
   )}:${padNumberWith0Zero(currentMinute)}`;
   const DEFAULT_DATE = formatDate(new Date());
   const [events, setEvents] = useState<EventSourceInput>([]);
   const [displayedEventData, setDisplayedEventData] = useState(
-    {} as DisplayedEventData,
+    {} as DisplayedEventData
   );
   const [showOverlay, setShowOverlay] = useState<boolean>(false);
   const [inEditMode, setInEditMode] = useState<boolean>(false);
@@ -93,13 +93,18 @@ const App = () => {
   const [modalAllDay, setModalAllDay] = useState<boolean>(false);
   const [apiError, setApiError] = useState<boolean>(false);
 
+  const flashApiErrorMessage = () => {
+    setApiError(true);
+    setTimeout(() => setApiError(false), 4000);
+  };
+
   useEffect(() => {
     getEntries()
       .then((entries) => {
         setEvents(entries);
       })
       .catch(() => {
-        setApiError(true);
+        flashApiErrorMessage();
       });
   }, []);
 
@@ -121,21 +126,29 @@ const App = () => {
       endTimeUtc,
       allDay,
     }).catch(() => {
-      setApiError(true);
+      flashApiErrorMessage();
     });
-    getEntries().then((entries) => {
-      setEvents(entries);
-      setShowOverlay(false);
-      setInCreateMode(false);
-    });
+    getEntries()
+      .then((entries) => {
+        setEvents(entries);
+        setShowOverlay(false);
+        setInCreateMode(false);
+      })
+      .catch(() => {
+        flashApiErrorMessage();
+      });
   };
 
   const getEntryDetails = (entryId: string) => {
-    getEntry(entryId).then((data) => {
-      setDisplayedEventData(data);
-      setShowOverlay(true);
-      setInEditMode(false);
-    });
+    getEntry(entryId)
+      .then((data) => {
+        setDisplayedEventData(data);
+        setShowOverlay(true);
+        setInEditMode(false);
+      })
+      .catch(() => {
+        flashApiErrorMessage();
+      });
   };
 
   const openModal = (arg: EventClickArg) => {
@@ -145,11 +158,17 @@ const App = () => {
 
   const handleDeleteEntry = async (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    await deleteEntry(displayedEventData._id!);
-    getEntries().then((entries) => {
-      setEvents(entries);
-      setShowOverlay(false);
-    });
+    deleteEntry(displayedEventData._id!)
+      .then(() => {
+        getEntries().then((entries) => {
+          setEvents(entries);
+          setShowOverlay(false);
+        });
+      })
+      .catch(() => {
+        setShowOverlay(false);
+        flashApiErrorMessage();
+      });
   };
 
   const handleEditEntry = () => setInEditMode(true);
@@ -172,18 +191,24 @@ const App = () => {
     const entryId = displayedEventData._id;
     const startTimeUtc = new Date(getDateTimeString(startDate, startTime));
     const endTimeUtc = new Date(getDateTimeString(endDate, endTime));
+    console.log("inside update entry");
     updateEntry(entryId, {
       title,
       description,
       startTimeUtc,
       endTimeUtc,
       allDay,
-    }).then(() => {
-      getEntryDetails(entryId);
-      getEntries().then((entries) => {
-        setEvents(entries);
+    })
+      .then(() => {
+        getEntryDetails(entryId);
+        getEntries().then((entries) => {
+          setEvents(entries);
+        });
+      })
+      .catch(() => {
+        setShowOverlay(false);
+        flashApiErrorMessage();
       });
-    });
   };
 
   return (
@@ -232,10 +257,10 @@ const App = () => {
                 dateClick={(DateClickObject) => {
                   setModalDate(formatDate(DateClickObject.date));
                   setModalStartTime(
-                    formatTime(DateClickObject.date.toUTCString()),
+                    formatTime(DateClickObject.date.toUTCString())
                   );
                   setModalEndTime(
-                    oneHourLater(DateClickObject.date.toUTCString()),
+                    oneHourLater(DateClickObject.date.toUTCString())
                   );
                   setModalAllDay(DateClickObject.allDay);
                   setInCreateMode(true);
@@ -293,13 +318,13 @@ const App = () => {
                     initialTitle={displayedEventData.title}
                     initialDescription={displayedEventData.description}
                     initialStartDate={formatDate(
-                      new Date(displayedEventData.startTimeUtc),
+                      new Date(displayedEventData.startTimeUtc)
                     )}
                     initialEndDate={formatDate(
-                      new Date(displayedEventData.endTimeUtc),
+                      new Date(displayedEventData.endTimeUtc)
                     )}
                     initialStartTime={formatTime(
-                      displayedEventData.startTimeUtc,
+                      displayedEventData.startTimeUtc
                     )}
                     initialEndTime={formatTime(displayedEventData.endTimeUtc)}
                     initialAllDay={displayedEventData.allDay}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -120,6 +120,8 @@ const App = () => {
       startTimeUtc,
       endTimeUtc,
       allDay,
+    }).catch(() => {
+      setApiError(true);
     });
     getEntries().then((entries) => {
       setEvents(entries);

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -192,7 +192,7 @@ const App = () => {
     const entryId = displayedEventData._id;
     const startTimeUtc = new Date(getDateTimeString(startDate, startTime));
     const endTimeUtc = new Date(getDateTimeString(endDate, endTime));
-    console.log("inside update entry");
+
     updateEntry(entryId, {
       title,
       description,

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -147,6 +147,7 @@ const App = () => {
         setInEditMode(false);
       })
       .catch(() => {
+        setShowOverlay(false);
         flashApiErrorMessage();
       });
   };

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -73,15 +73,15 @@ const App = () => {
   const currentHour: number = new Date().getHours();
   const currentMinute: number = new Date().getMinutes();
   const DEFAULT_START_TIME: string = `${padNumberWith0Zero(
-    currentHour
+    currentHour,
   )}:${padNumberWith0Zero(currentMinute)}`;
   const DEFAULT_END_TIME: string = `${padNumberWith0Zero(
-    currentHour + 1
+    currentHour + 1,
   )}:${padNumberWith0Zero(currentMinute)}`;
   const DEFAULT_DATE = formatDate(new Date());
   const [events, setEvents] = useState<EventSourceInput>([]);
   const [displayedEventData, setDisplayedEventData] = useState(
-    {} as DisplayedEventData
+    {} as DisplayedEventData,
   );
   const [showOverlay, setShowOverlay] = useState<boolean>(false);
   const [inEditMode, setInEditMode] = useState<boolean>(false);
@@ -91,7 +91,7 @@ const App = () => {
     useState<string>(DEFAULT_START_TIME);
   const [modalEndTime, setModalEndTime] = useState<string>(DEFAULT_END_TIME);
   const [modalAllDay, setModalAllDay] = useState<boolean>(false);
-  const [apiError, setApiError] = useState<boolean>(true);
+  const [apiError, setApiError] = useState<boolean>(false);
 
   useEffect(() => {
     getEntries().then((entries) => {
@@ -225,10 +225,10 @@ const App = () => {
                 dateClick={(DateClickObject) => {
                   setModalDate(formatDate(DateClickObject.date));
                   setModalStartTime(
-                    formatTime(DateClickObject.date.toUTCString())
+                    formatTime(DateClickObject.date.toUTCString()),
                   );
                   setModalEndTime(
-                    oneHourLater(DateClickObject.date.toUTCString())
+                    oneHourLater(DateClickObject.date.toUTCString()),
                   );
                   setModalAllDay(DateClickObject.allDay);
                   setInCreateMode(true);
@@ -286,13 +286,13 @@ const App = () => {
                     initialTitle={displayedEventData.title}
                     initialDescription={displayedEventData.description}
                     initialStartDate={formatDate(
-                      new Date(displayedEventData.startTimeUtc)
+                      new Date(displayedEventData.startTimeUtc),
                     )}
                     initialEndDate={formatDate(
-                      new Date(displayedEventData.endTimeUtc)
+                      new Date(displayedEventData.endTimeUtc),
                     )}
                     initialStartTime={formatTime(
-                      displayedEventData.startTimeUtc
+                      displayedEventData.startTimeUtc,
                     )}
                     initialEndTime={formatTime(displayedEventData.endTimeUtc)}
                     initialAllDay={displayedEventData.allDay}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -19,13 +19,14 @@ import interactionPlugin from "@fullcalendar/interaction";
 import timeGridPlugin from "@fullcalendar/timegrid";
 import listPlugin from "@fullcalendar/list";
 import { AddIcon } from "@chakra-ui/icons";
+
 import {
   Alert,
   AlertIcon,
-  AlertTitle,
   AlertDescription,
   Box,
   Button,
+  CloseButton,
   IconButton,
   Modal,
   ModalOverlay,
@@ -35,6 +36,7 @@ import {
   ModalBody,
   ModalCloseButton,
   ChakraProvider,
+  useDisclosure,
 } from "@chakra-ui/react";
 import {
   getEntry,
@@ -94,9 +96,14 @@ const App = () => {
   const [apiError, setApiError] = useState<boolean>(false);
 
   useEffect(() => {
-    getEntries().then((entries) => {
-      setEvents(entries);
-    });
+    getEntries()
+      .then((entries) => {
+        setEvents(entries);
+      })
+      .catch(() => {
+        console.log("errorrr");
+        setApiError(true);
+      });
   }, []);
 
   const handleCreateEntry = async ({
@@ -180,16 +187,30 @@ const App = () => {
     });
   };
 
+  const {
+    isOpen: isVisible,
+    onClose,
+    onOpen,
+  } = useDisclosure({ defaultIsOpen: false });
+
   return (
     <div className="App">
       <ChakraProvider>
         <Box>
-          {apiError && (
+          {isVisible && (
             <Alert status="error" justifyContent="center">
               <AlertIcon />
               <AlertDescription>Oops! Something went wrong.</AlertDescription>
+              <CloseButton
+                alignSelf="flex-start"
+                position="relative"
+                right={-1}
+                top={-1}
+                onClick={onClose}
+              />
             </Alert>
           )}
+
           <div className={s.mainContainer}>
             <div className={s.leftSidePanel}>
               <IconButton

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -20,6 +20,10 @@ import timeGridPlugin from "@fullcalendar/timegrid";
 import listPlugin from "@fullcalendar/list";
 import { AddIcon } from "@chakra-ui/icons";
 import {
+  Alert,
+  AlertIcon,
+  AlertTitle,
+  AlertDescription,
   Box,
   Button,
   IconButton,
@@ -87,6 +91,7 @@ const App = () => {
     useState<string>(DEFAULT_START_TIME);
   const [modalEndTime, setModalEndTime] = useState<string>(DEFAULT_END_TIME);
   const [modalAllDay, setModalAllDay] = useState<boolean>(false);
+  const [apiError, setApiError] = useState<boolean>(true);
 
   useEffect(() => {
     getEntries().then((entries) => {
@@ -179,6 +184,12 @@ const App = () => {
     <div className="App">
       <ChakraProvider>
         <Box>
+          {apiError && (
+            <Alert status="error" justifyContent="center">
+              <AlertIcon />
+              <AlertDescription>Oops! Something went wrong.</AlertDescription>
+            </Alert>
+          )}
           <div className={s.mainContainer}>
             <div className={s.leftSidePanel}>
               <IconButton

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -26,7 +26,6 @@ import {
   AlertDescription,
   Box,
   Button,
-  CloseButton,
   IconButton,
   Modal,
   ModalOverlay,
@@ -36,7 +35,6 @@ import {
   ModalBody,
   ModalCloseButton,
   ChakraProvider,
-  useDisclosure,
 } from "@chakra-ui/react";
 import {
   getEntry,
@@ -101,7 +99,6 @@ const App = () => {
         setEvents(entries);
       })
       .catch(() => {
-        console.log("errorrr");
         setApiError(true);
       });
   }, []);
@@ -187,27 +184,14 @@ const App = () => {
     });
   };
 
-  const {
-    isOpen: isVisible,
-    onClose,
-    onOpen,
-  } = useDisclosure({ defaultIsOpen: false });
-
   return (
     <div className="App">
       <ChakraProvider>
         <Box>
-          {isVisible && (
+          {apiError && (
             <Alert status="error" justifyContent="center">
               <AlertIcon />
               <AlertDescription>Oops! Something went wrong.</AlertDescription>
-              <CloseButton
-                alignSelf="flex-start"
-                position="relative"
-                right={-1}
-                top={-1}
-                onClick={onClose}
-              />
             </Alert>
           )}
 

--- a/ui/src/client.test.ts
+++ b/ui/src/client.test.ts
@@ -8,6 +8,11 @@ import {
 
 describe("client functions", () => {
   describe("getEntries", () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+      jest.clearAllMocks();
+    });
+
     it("succeeds", async () => {
       const mockResponse = {
         status: 200,
@@ -46,9 +51,28 @@ describe("client functions", () => {
         },
       ]);
     });
+
+    it("throws an error on failure", () => {
+      const mockResponse = {
+        status: 400,
+        json: () => {
+          return [{}] as any;
+        },
+      } as Response;
+
+      jest.spyOn(window, "fetch").mockResolvedValue(mockResponse);
+      expect(() => getEntries()).rejects.toThrowError(
+        new Error("Get entries request failed")
+      );
+    });
   });
 
   describe("getEntry", () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+      jest.clearAllMocks();
+    });
+
     it("succeeds", async () => {
       const mockResponse = {
         status: 200,
@@ -89,9 +113,28 @@ describe("client functions", () => {
         __v: 0,
       });
     });
+
+    it("throws an error on failure", () => {
+      const mockResponse = {
+        status: 400,
+        json: () => {
+          return [{}] as any;
+        },
+      } as Response;
+
+      jest.spyOn(window, "fetch").mockResolvedValue(mockResponse);
+      expect(() => getEntry("638d815856e5c70955565b7e")).rejects.toThrowError(
+        new Error("Get entry request failed")
+      );
+    });
   });
 
   describe("createEntry", () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+      jest.clearAllMocks();
+    });
+
     it("succeeds", async () => {
       const mockResponse = {
         status: 200,
@@ -138,9 +181,34 @@ describe("client functions", () => {
         __v: 0,
       });
     });
+
+    it("throws an error on failure", () => {
+      const mockResponse = {
+        status: 400,
+        json: () => {
+          return [{}] as any;
+        },
+      } as Response;
+
+      jest.spyOn(window, "fetch").mockResolvedValue(mockResponse);
+      expect(() =>
+        createEntry({
+          title: "Ange's Bat Mitzvah",
+          description: "Ange is turning 13!",
+          startTimeUtc: new Date("2024-06-06T01:07:00.000Z"),
+          endTimeUtc: new Date("2024-06-06T01:07:00.000Z"),
+          allDay: true,
+        })
+      ).rejects.toThrowError(new Error("Create entry request failed"));
+    });
   });
 
   describe("updateEntry", () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+      jest.clearAllMocks();
+    });
+
     it("succeeds", async () => {
       const mockResponse = {
         status: 200,
@@ -174,7 +242,7 @@ describe("client functions", () => {
       });
       expect(fetchSpy).toHaveBeenCalled();
       expect(fetchSpy.mock.calls[0][1]).toEqual(
-        expect.objectContaining({ method: "PATCH" }),
+        expect.objectContaining({ method: "PATCH" })
       );
 
       expect(result).toEqual({
@@ -192,7 +260,7 @@ describe("client functions", () => {
       });
     });
 
-    it.only("throws an error on failure", async () => {
+    it("throws an error on failure", async () => {
       const mockResponse = {
         status: 400,
         json: () => {
@@ -200,9 +268,7 @@ describe("client functions", () => {
         },
       } as Response;
 
-      const fetchSpy = jest
-        .spyOn(window, "fetch")
-        .mockResolvedValue(mockResponse);
+      jest.spyOn(window, "fetch").mockResolvedValue(mockResponse);
 
       expect(() =>
         updateEntry("638d815856e5c70955565b7e", {
@@ -212,12 +278,16 @@ describe("client functions", () => {
           endTimeUtc: new Date("2024-06-06T01:07:00.000Z"),
           allDay: true,
         })
-      ).toThrowError();
-      // ).toThrow(new Error("Update request failed"));
+      ).rejects.toThrow(new Error("Update entry request failed"));
     });
   });
 
-  describe.only("deleteEntry", () => {
+  describe("deleteEntry", () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+      jest.clearAllMocks();
+    });
+
     it("succeeds", async () => {
       const mockResponse = {
         status: 200,
@@ -236,6 +306,21 @@ describe("client functions", () => {
       expect(result).toEqual({
         status: 200,
       });
+    });
+
+    it("throws an error on failure", async () => {
+      const mockResponse = {
+        status: 400,
+        json: () => {
+          return {} as any;
+        },
+      } as Response;
+
+      jest.spyOn(window, "fetch").mockResolvedValue(mockResponse);
+
+      expect(() => deleteEntry("638d815856e5c70955565b7e")).rejects.toThrow(
+        new Error("Delete entry request failed")
+      );
     });
   });
 });

--- a/ui/src/client.test.ts
+++ b/ui/src/client.test.ts
@@ -7,12 +7,12 @@ import {
 } from "./client";
 
 describe("client functions", () => {
-  describe("getEntries", () => {
-    afterEach(() => {
-      jest.restoreAllMocks();
-      jest.clearAllMocks();
-    });
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
 
+  describe("getEntries", () => {
     it("succeeds", async () => {
       const mockResponse = {
         status: 200,
@@ -68,11 +68,6 @@ describe("client functions", () => {
   });
 
   describe("getEntry", () => {
-    afterEach(() => {
-      jest.restoreAllMocks();
-      jest.clearAllMocks();
-    });
-
     it("succeeds", async () => {
       const mockResponse = {
         status: 200,
@@ -130,11 +125,6 @@ describe("client functions", () => {
   });
 
   describe("createEntry", () => {
-    afterEach(() => {
-      jest.restoreAllMocks();
-      jest.clearAllMocks();
-    });
-
     it("succeeds", async () => {
       const mockResponse = {
         status: 200,
@@ -204,11 +194,6 @@ describe("client functions", () => {
   });
 
   describe("updateEntry", () => {
-    afterEach(() => {
-      jest.restoreAllMocks();
-      jest.clearAllMocks();
-    });
-
     it("succeeds", async () => {
       const mockResponse = {
         status: 200,
@@ -283,11 +268,6 @@ describe("client functions", () => {
   });
 
   describe("deleteEntry", () => {
-    afterEach(() => {
-      jest.restoreAllMocks();
-      jest.clearAllMocks();
-    });
-
     it("succeeds", async () => {
       const mockResponse = {
         status: 200,

--- a/ui/src/client.test.ts
+++ b/ui/src/client.test.ts
@@ -191,6 +191,30 @@ describe("client functions", () => {
         __v: 0,
       });
     });
+
+    it.only("throws an error on failure", async () => {
+      const mockResponse = {
+        status: 400,
+        json: () => {
+          return {} as any;
+        },
+      } as Response;
+
+      const fetchSpy = jest
+        .spyOn(window, "fetch")
+        .mockResolvedValue(mockResponse);
+
+      expect(() =>
+        updateEntry("638d815856e5c70955565b7e", {
+          title: "Barbies's Bat Mitzvah",
+          description: "Barbie is turning 13!",
+          startTimeUtc: new Date("2024-06-06T01:07:00.000Z"),
+          endTimeUtc: new Date("2024-06-06T01:07:00.000Z"),
+          allDay: true,
+        })
+      ).toThrowError();
+      // ).toThrow(new Error("Update request failed"));
+    });
   });
 
   describe.only("deleteEntry", () => {

--- a/ui/src/client.ts
+++ b/ui/src/client.ts
@@ -82,6 +82,9 @@ const updateEntry = async (
       allDay,
     }),
   });
+  if (!response.ok) {
+    throw new Error("Update request failed");
+  }
   const result = await response.json();
   return result;
 };

--- a/ui/src/client.ts
+++ b/ui/src/client.ts
@@ -11,7 +11,6 @@ const notOk = (status: number) => {
 };
 
 const getEntries = async () => {
-  console.log("inside get entries");
   return fetch("http://localhost:4000/entries", {
     method: "GET",
     headers: {

--- a/ui/src/client.ts
+++ b/ui/src/client.ts
@@ -82,7 +82,7 @@ const createEntry = async ({
 
 const updateEntry = async (
   entryId: string,
-  { title, startTimeUtc, endTimeUtc, description, allDay }: CalendarEntryInput,
+  { title, startTimeUtc, endTimeUtc, description, allDay }: CalendarEntryInput
 ) => {
   const response = await fetch(`http://localhost:4000/entries/${entryId}`, {
     method: "PATCH",

--- a/ui/src/client.ts
+++ b/ui/src/client.ts
@@ -6,14 +6,24 @@ interface CalendarEntryInput {
   allDay: boolean;
 }
 
+const notOk = (status: number) => {
+  return !status.toString().match(/2\d+/);
+};
+
 const getEntries = async () => {
+  console.log("inside get entries");
   return fetch("http://localhost:4000/entries", {
     method: "GET",
     headers: {
       "Content-Type": "application/json",
     },
   })
-    .then((response) => response.json())
+    .then((response) => {
+      if (notOk(response.status)) {
+        throw new Error("Get entries request failed");
+      }
+      return response.json();
+    })
     .then((data) => {
       const result = data.map((event: any) => {
         return {
@@ -34,7 +44,12 @@ const getEntry = async (entryId: string) => {
     headers: {
       "Content-Type": "application/json",
     },
-  }).then((response) => response.json());
+  }).then((response) => {
+    if (notOk(response.status)) {
+      throw new Error("Get entry request failed");
+    }
+    return response.json();
+  });
 };
 
 const createEntry = async ({
@@ -59,13 +74,16 @@ const createEntry = async ({
       allDay,
     }),
   });
+  if (notOk(response.status)) {
+    throw new Error("Create entry request failed");
+  }
   const result = await response.json();
   return result;
 };
 
 const updateEntry = async (
   entryId: string,
-  { title, startTimeUtc, endTimeUtc, description, allDay }: CalendarEntryInput,
+  { title, startTimeUtc, endTimeUtc, description, allDay }: CalendarEntryInput
 ) => {
   const response = await fetch(`http://localhost:4000/entries/${entryId}`, {
     method: "PATCH",
@@ -82,8 +100,8 @@ const updateEntry = async (
       allDay,
     }),
   });
-  if (!response.ok) {
-    throw new Error("Update request failed");
+  if (notOk(response.status)) {
+    throw new Error("Update entry request failed");
   }
   const result = await response.json();
   return result;
@@ -97,6 +115,9 @@ const deleteEntry = async (entryId: string) => {
     },
   });
   const result = await response;
+  if (notOk(response.status)) {
+    throw new Error("Delete entry request failed");
+  }
   return result;
 };
 

--- a/ui/src/client.ts
+++ b/ui/src/client.ts
@@ -82,7 +82,7 @@ const createEntry = async ({
 
 const updateEntry = async (
   entryId: string,
-  { title, startTimeUtc, endTimeUtc, description, allDay }: CalendarEntryInput
+  { title, startTimeUtc, endTimeUtc, description, allDay }: CalendarEntryInput,
 ) => {
   const response = await fetch(`http://localhost:4000/entries/${entryId}`, {
     method: "PATCH",


### PR DESCRIPTION
_Closes:_ #53 

## Summary of changes
This PR adds an error banner message that flashes anytime an API error happens. It also adds try catch structures to the api client methods and catch blocks to the backend calls that get invoked from the App component.

## Dev notes

## Testing

- [x] Unit tests

#### Screenshot of UI (local testing in browser)
![Screen Shot 2022-12-26 at 11 05 17 AM](https://user-images.githubusercontent.com/15992415/209577156-06b4ef07-dc5b-441d-85ff-05f99a8502e1.png)
