### PR TITLE
Cal 89 union types for recurring

### DIFF
--- a/api/controllers/calendarEntry.controller.ts
+++ b/api/controllers/calendarEntry.controller.ts
@@ -60,19 +60,20 @@ type RecurringChildEntry = {
 };
 
 const isNonRecurringEntry = (entry) => {
-  return (entry as NonRecurringEntry).recurring == false;
+  return (entry as NonRecurringEntry).recurring === false;
 };
 
 const isRecurringParentEntry = (entry) => {
   return (
-    (entry as RecurringParentEntry).recurring == true &&
+    (entry as RecurringParentEntry).recurring === true &&
     (entry as RecurringParentEntry).frequency !== undefined
   );
 };
 
+// Not currently used but will be used during future features
 const isRecurringChildEntry = (entry) => {
   return (
-    (entry as RecurringChildEntry).recurring == true &&
+    (entry as RecurringChildEntry).recurring === true &&
     (entry as RecurringChildEntry).recurringEventId !== undefined
   );
 };


### PR DESCRIPTION
_Closes:_ #89

## Summary of changes
This PR introduces union types for nonRecurringEntry, recurringParentEntry and recurringChildEntry. It also creates helper functions per Typescript's documentation example to help identify which type something is. See the following example from the [docs](https://www.typescriptlang.org/docs/handbook/2/narrowing.html):

```
function isFish(pet: Fish | Bird): pet is Fish {
  return (pet as Fish).swim !== undefined;
}
```

## Dev notes

## Testing

No new tests

#### Screenshot of UI (local testing in browser)
