### PR TITLE
Cal 97 fix mobile header

### DIFF
--- a/ui/src/App.module.css
+++ b/ui/src/App.module.css
@@ -1,6 +1,8 @@
 .mainContainer {
   display: flex;
+  flex-direction: column;
 }
+
 .allDay {
   font-style: italic;
   font-weight: 600;
@@ -25,7 +27,7 @@
 
 .leftSidePanel {
   display: flex;
-  margin: 10px;
+  margin-bottom: 10px;
   width: 15vw;
 }
 
@@ -49,8 +51,10 @@
 }
 
 .fullCalendarUI {
-  padding: 20px 50px 0 0;
-  width: 80vw;
+  padding: 20px;
+  width: 100%;
+  max-width: 1100px;
+  align-self: center;
 }
 
 .saveButton {
@@ -99,10 +103,17 @@
   }
 
   .fullCalendarUI {
-    display: flex;
-    padding: 25px;
-    position: relative;
+    padding: 10px;
     width: 100%;
+  }
+
+  :global(.fc-toolbar) {
+    display: block !important;
+    text-align: center;
+  }
+
+  :global(.fc-button-group) {
+    width: 200px;
   }
 
   .buttonText {

--- a/ui/src/App.module.css
+++ b/ui/src/App.module.css
@@ -51,10 +51,10 @@
 }
 
 .fullCalendarUI {
+  align-self: center;
+  max-width: 1100px;
   padding: 20px;
   width: 100%;
-  max-width: 1100px;
-  align-self: center;
 }
 
 .saveButton {
@@ -95,10 +95,10 @@
   }
 
   .createEventButton {
-    display: flex;
-    justify-content: center;
     background: rgb(157, 156, 156);
+    display: flex;
     height: 50px;
+    justify-content: center;
     width: 100px;
   }
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -78,15 +78,15 @@ const App = () => {
   const currentHour: number = new Date().getHours();
   const currentMinute: number = new Date().getMinutes();
   const DEFAULT_START_TIME: string = `${padNumberWith0Zero(
-    currentHour,
+    currentHour
   )}:${padNumberWith0Zero(currentMinute)}`;
   const DEFAULT_END_TIME: string = `${padNumberWith0Zero(
-    currentHour + 1,
+    currentHour + 1
   )}:${padNumberWith0Zero(currentMinute)}`;
   const DEFAULT_DATE = formatDate(new Date());
   const [events, setEvents] = useState<EventSourceInput>([]);
   const [displayedEventData, setDisplayedEventData] = useState(
-    {} as DisplayedEventData,
+    {} as DisplayedEventData
   );
   const [showOverlay, setShowOverlay] = useState<boolean>(false);
   const [inEditMode, setInEditMode] = useState<boolean>(false);
@@ -247,21 +247,24 @@ const App = () => {
           )}
 
           <div className={s.mainContainer}>
-            <div className={s.leftSidePanel}>
-              <IconButton
-                aria-label="add event"
-                icon={<AddIcon boxSize={5} w={5} h={5} />}
-                onClick={() => {
-                  setModalStartDate(DEFAULT_DATE);
-                  setModalEndDate(DEFAULT_DATE);
-                  setModalStartTime(DEFAULT_START_TIME);
-                  setModalEndTime(DEFAULT_END_TIME);
-                  setInCreateMode(true);
-                  setShowOverlay(true);
-                }}
-              />
-            </div>
             <div className={s.fullCalendarUI}>
+              <div className={s.leftSidePanel}>
+                <div>
+                  <IconButton
+                    aria-label="add event"
+                    size="lg"
+                    icon={<AddIcon boxSize={7} w={7} h={7} />}
+                    onClick={() => {
+                      setModalStartDate(DEFAULT_DATE);
+                      setModalEndDate(DEFAULT_DATE);
+                      setModalStartTime(DEFAULT_START_TIME);
+                      setModalEndTime(DEFAULT_END_TIME);
+                      setInCreateMode(true);
+                      setShowOverlay(true);
+                    }}
+                  />
+                </div>
+              </div>
               <FullCalendar
                 plugins={[
                   dayGridPlugin,
@@ -343,13 +346,13 @@ const App = () => {
                     initialTitle={displayedEventData.title}
                     initialDescription={displayedEventData.description}
                     initialStartDate={formatDate(
-                      new Date(displayedEventData.startTimeUtc),
+                      new Date(displayedEventData.startTimeUtc)
                     )}
                     initialEndDate={formatDate(
-                      new Date(displayedEventData.endTimeUtc),
+                      new Date(displayedEventData.endTimeUtc)
                     )}
                     initialStartTime={formatTime(
-                      displayedEventData.startTimeUtc,
+                      displayedEventData.startTimeUtc
                     )}
                     initialEndTime={formatTime(displayedEventData.endTimeUtc)}
                     initialAllDay={displayedEventData.allDay}


### PR DESCRIPTION
_Closes:_ #97 

## Summary of changes
This PR fixes the mobile styling of the headers and introduces a max width to the entire page so that it looks good on big screens as well.

## Dev notes

## Testing

- [ ] Unit tests

#### Screenshot of UI (local testing in browser)

#### Mobile

![Screen Shot 2022-12-28 at 4 51 18 PM](https://user-images.githubusercontent.com/15992415/209889964-86221d05-392d-47ef-bdd2-b6b183e3da38.png)


#### Wide screen
![Screen Shot 2022-12-28 at 4 53 14 PM](https://user-images.githubusercontent.com/15992415/209889960-6cdba239-cd21-4bdb-a282-6429bb0dc7c3.png)

