### PR TITLE
Cal 101 update default time

### DIFF
--- a/e2e/cypress/e2e/spec.cy.js
+++ b/e2e/cypress/e2e/spec.cy.js
@@ -2,6 +2,7 @@ import "@4tw/cypress-drag-drop";
 
 describe("journey test", () => {
   let postTwoId;
+  let postThreeId;
 
   beforeEach(() => {
     // For an unknown reason this sets the current
@@ -12,6 +13,7 @@ describe("journey test", () => {
 
   after(() => {
     cy.request("DELETE", `http://localhost:4000/entries/${postTwoId}`);
+    cy.request("DELETE", `http://localhost:4000/entries/${postThreeId}`);
   });
 
   it("can create and update an event", () => {
@@ -134,7 +136,7 @@ describe("journey test", () => {
     cy.contains("label", "All Day").click();
     cy.contains("button", "Create Event").click();
     cy.wait("@createEntry").then((interception) => {
-      postTwoId = interception.response.body._id;
+      postThreeId = interception.response.body._id;
     });
 
     // Open event

--- a/e2e/cypress/e2e/spec.cy.js
+++ b/e2e/cypress/e2e/spec.cy.js
@@ -101,7 +101,7 @@ describe("journey test", () => {
     cy.contains("button", "Create Event").click();
   });
 
-  it.only("shows correct default time when existing allDay event is changed to not be `allDay`", () => {
+  it("shows correct default time when existing allDay event is changed to not be `allDay`", () => {
     cy.visit("http://localhost:3000");
     cy.intercept({
       method: "POST",
@@ -119,6 +119,10 @@ describe("journey test", () => {
     });
     cy.contains("button", "Create Event").click();
 
+    cy.wait("@createEntry").then((interception) => {
+      postTwoId = interception.response.body._id;
+    });
+
     cy.contains("Bye").click();
     cy.contains("Edit").click();
 
@@ -126,6 +130,7 @@ describe("journey test", () => {
 
     cy.get(`[id="startTime"]`).should("have.value", "03:12");
     cy.get(`[id="endTime"]`).should("have.value", "04:12");
+    cy.contains("button", "Save").click();
   });
 
   describe("month view", () => {

--- a/e2e/cypress/e2e/spec.cy.js
+++ b/e2e/cypress/e2e/spec.cy.js
@@ -84,6 +84,8 @@ describe("journey test", () => {
       url: "/entries",
       hostname: "localhost",
     }).as("createEntry");
+
+    // Creating new event from "+"
     cy.get(`[aria-label="add event"]`).click();
     cy.contains("label", "Title").click().type("Bye");
     cy.contains("label", "Description").click().type("It's a beautiful night");
@@ -96,46 +98,52 @@ describe("journey test", () => {
 
     cy.contains("label", "All Day").click();
 
+    // Create event modal has correct time defaults
     cy.get(`[id="startTime"]`).should("have.value", "04:00");
     cy.get(`[id="endTime"]`).should("have.value", "05:00");
     cy.contains("button", "Create Event").click();
   });
 
-  it("shows correct default time when allDay event is changed to not be `allDay`", () => {
+  it("shows correct default time when new and existing allDay event is changed to not be `allDay`", () => {
     cy.visit("http://localhost:3000");
     cy.intercept({
       method: "POST",
       url: "/entries",
       hostname: "localhost",
     }).as("createEntry");
+
+    // Creating new event from clicking on a date
     cy.get(`[data-date="2022-12-14"]`).click();
     cy.contains("label", "Title").click().type("Bye");
     cy.contains("label", "Description").click().type("It's a beautiful night");
     cy.contains("label", "Start Date").click().type("2022-12-14");
     cy.contains("label", "End Date").click().type("2022-12-14");
 
+    // Assert All Day is default true
     cy.contains("label", "All Day").within(() => {
       cy.get('[type="checkbox"]').should("be.checked");
     });
 
+    // Uncheck All Day
+    // Assert time defaults are correct
     cy.contains("label", "All Day").click();
-
     cy.get(`[id="startTime"]`).should("have.value", "04:00");
     cy.get(`[id="endTime"]`).should("have.value", "05:00");
 
+    // Recheck All Day to create event
     cy.contains("label", "All Day").click();
-
     cy.contains("button", "Create Event").click();
-
     cy.wait("@createEntry").then((interception) => {
       postTwoId = interception.response.body._id;
     });
 
+    // Open event
     cy.contains("Bye").click();
     cy.contains("Edit").click();
 
+    // Uncheck All Day
+    // Assert time defaults are correct
     cy.contains("label", "All Day").click();
-
     cy.get(`[id="startTime"]`).should("have.value", "04:00");
     cy.get(`[id="endTime"]`).should("have.value", "05:00");
     cy.contains("button", "Save").click();

--- a/e2e/cypress/e2e/spec.cy.js
+++ b/e2e/cypress/e2e/spec.cy.js
@@ -79,7 +79,11 @@ describe("journey test", () => {
 
   it("shows correct default time when uncreated event is changed to not be `allDay`", () => {
     cy.visit("http://localhost:3000");
-
+    cy.intercept({
+      method: "POST",
+      url: "/entries",
+      hostname: "localhost",
+    }).as("createEntry");
     cy.get(`[aria-label="add event"]`).click();
     cy.contains("label", "Title").click().type("Bye");
     cy.contains("label", "Description").click().type("It's a beautiful night");
@@ -95,6 +99,33 @@ describe("journey test", () => {
     cy.get(`[id="startTime"]`).should("have.value", "03:12");
     cy.get(`[id="endTime"]`).should("have.value", "04:12");
     cy.contains("button", "Create Event").click();
+  });
+
+  it.only("shows correct default time when existing allDay event is changed to not be `allDay`", () => {
+    cy.visit("http://localhost:3000");
+    cy.intercept({
+      method: "POST",
+      url: "/entries",
+      hostname: "localhost",
+    }).as("createEntry");
+    cy.get(`[data-date="2022-12-14"]`).click();
+    cy.contains("label", "Title").click().type("Bye");
+    cy.contains("label", "Description").click().type("It's a beautiful night");
+    cy.contains("label", "Start Date").click().type("2022-12-14");
+    cy.contains("label", "End Date").click().type("2022-12-14");
+
+    cy.contains("label", "All Day").within(() => {
+      cy.get('[type="checkbox"]').should("be.checked");
+    });
+    cy.contains("button", "Create Event").click();
+
+    cy.contains("Bye").click();
+    cy.contains("Edit").click();
+
+    cy.contains("label", "All Day").click();
+
+    cy.get(`[id="startTime"]`).should("have.value", "03:12");
+    cy.get(`[id="endTime"]`).should("have.value", "04:12");
   });
 
   describe("month view", () => {
@@ -118,7 +149,9 @@ describe("journey test", () => {
       cy.get(".chakra-modal__body").within(() => {
         cy.get(`[id="startDate"]`).should("have.value", "2022-12-26");
         cy.get(`[id="endDate"]`).should("have.value", "2022-12-26");
-        cy.get('[type="checkbox"]').should("be.checked");
+        cy.contains("label", "All Day").within(() => {
+          cy.get('[type="checkbox"]').should("be.checked");
+        });
       });
       cy.get(`[aria-label="Close"]`).click();
     });

--- a/e2e/cypress/e2e/spec.cy.js
+++ b/e2e/cypress/e2e/spec.cy.js
@@ -96,8 +96,8 @@ describe("journey test", () => {
 
     cy.contains("label", "All Day").click();
 
-    cy.get(`[id="startTime"]`).should("have.value", "03:12");
-    cy.get(`[id="endTime"]`).should("have.value", "04:12");
+    cy.get(`[id="startTime"]`).should("have.value", "04:00");
+    cy.get(`[id="endTime"]`).should("have.value", "05:00");
     cy.contains("button", "Create Event").click();
   });
 
@@ -120,8 +120,8 @@ describe("journey test", () => {
 
     cy.contains("label", "All Day").click();
 
-    cy.get(`[id="startTime"]`).should("have.value", "03:12");
-    cy.get(`[id="endTime"]`).should("have.value", "04:12");
+    cy.get(`[id="startTime"]`).should("have.value", "04:00");
+    cy.get(`[id="endTime"]`).should("have.value", "05:00");
 
     cy.contains("label", "All Day").click();
 
@@ -136,8 +136,8 @@ describe("journey test", () => {
 
     cy.contains("label", "All Day").click();
 
-    cy.get(`[id="startTime"]`).should("have.value", "03:12");
-    cy.get(`[id="endTime"]`).should("have.value", "04:12");
+    cy.get(`[id="startTime"]`).should("have.value", "04:00");
+    cy.get(`[id="endTime"]`).should("have.value", "05:00");
     cy.contains("button", "Save").click();
   });
 

--- a/e2e/cypress/e2e/spec.cy.js
+++ b/e2e/cypress/e2e/spec.cy.js
@@ -101,7 +101,7 @@ describe("journey test", () => {
     cy.contains("button", "Create Event").click();
   });
 
-  it("shows correct default time when existing allDay event is changed to not be `allDay`", () => {
+  it("shows correct default time when allDay event is changed to not be `allDay`", () => {
     cy.visit("http://localhost:3000");
     cy.intercept({
       method: "POST",
@@ -117,6 +117,14 @@ describe("journey test", () => {
     cy.contains("label", "All Day").within(() => {
       cy.get('[type="checkbox"]').should("be.checked");
     });
+
+    cy.contains("label", "All Day").click();
+
+    cy.get(`[id="startTime"]`).should("have.value", "03:12");
+    cy.get(`[id="endTime"]`).should("have.value", "04:12");
+
+    cy.contains("label", "All Day").click();
+
     cy.contains("button", "Create Event").click();
 
     cy.wait("@createEntry").then((interception) => {

--- a/e2e/cypress/e2e/spec.cy.js
+++ b/e2e/cypress/e2e/spec.cy.js
@@ -3,6 +3,7 @@ import "@4tw/cypress-drag-drop";
 describe("journey test", () => {
   let postTwoId;
   let postThreeId;
+  let postFourId;
 
   beforeEach(() => {
     // For an unknown reason this sets the current
@@ -14,6 +15,7 @@ describe("journey test", () => {
   after(() => {
     cy.request("DELETE", `http://localhost:4000/entries/${postTwoId}`);
     cy.request("DELETE", `http://localhost:4000/entries/${postThreeId}`);
+    cy.request("DELETE", `http://localhost:4000/entries/${postFourId}`);
   });
 
   it("can create and update an event", () => {
@@ -104,6 +106,9 @@ describe("journey test", () => {
     cy.get(`[id="startTime"]`).should("have.value", "04:00");
     cy.get(`[id="endTime"]`).should("have.value", "05:00");
     cy.contains("button", "Create Event").click();
+    cy.wait("@createEntry").then((interception) => {
+      postThreeId = interception.response.body._id;
+    });
   });
 
   it("shows correct default time when new and existing allDay event is changed to not be `allDay`", () => {
@@ -116,7 +121,7 @@ describe("journey test", () => {
 
     // Creating new event from clicking on a date
     cy.get(`[data-date="2022-12-14"]`).click();
-    cy.contains("label", "Title").click().type("Bye");
+    cy.contains("label", "Title").click().type("Night");
     cy.contains("label", "Description").click().type("It's a beautiful night");
     cy.contains("label", "Start Date").click().type("2022-12-14");
     cy.contains("label", "End Date").click().type("2022-12-14");
@@ -136,11 +141,11 @@ describe("journey test", () => {
     cy.contains("label", "All Day").click();
     cy.contains("button", "Create Event").click();
     cy.wait("@createEntry").then((interception) => {
-      postThreeId = interception.response.body._id;
+      postFourId = interception.response.body._id;
     });
 
     // Open event
-    cy.contains("Bye").click();
+    cy.contains("Night").click();
     cy.contains("Edit").click();
 
     // Uncheck All Day

--- a/e2e/cypress/e2e/spec.cy.js
+++ b/e2e/cypress/e2e/spec.cy.js
@@ -5,9 +5,9 @@ describe("journey test", () => {
 
   beforeEach(() => {
     // For an unknown reason this sets the current
-    // day to Dec 26, not Nov 26. Leaving since this
+    // day to Dec 26, 3:12am not Nov 26. Leaving since this
     // is our only way of mocking out time in these tests
-    cy.clock(new Date(2022, 11, 26), ["Date"]);
+    cy.clock(new Date(2022, 11, 26, 3, 12), ["Date"]);
   });
 
   after(() => {
@@ -31,7 +31,7 @@ describe("journey test", () => {
     cy.contains("Hello").should("be.visible");
     cy.contains("It's a beautiful day").should("be.visible");
     cy.contains("Sat, Nov 26, 04:35 AM - Sun, Nov 27, 06:45 AM").should(
-      "be.visible"
+      "be.visible",
     );
     cy.contains("button", "Edit").click();
     cy.get(".chakra-modal__body").within(() => {
@@ -45,7 +45,7 @@ describe("journey test", () => {
     cy.contains("Hello Everyone").should("be.visible");
     cy.contains("It's a beautiful day").should("be.visible");
     cy.contains("Sun, Nov 27, 07:35 AM - Tue, Nov 29, 08:45 AM").should(
-      "be.visible"
+      "be.visible",
     );
     cy.contains("button", "Delete").click();
     cy.contains("Hello Everyone").should("not.exist");
@@ -75,6 +75,26 @@ describe("journey test", () => {
     cy.contains("It's a beautiful night").should("be.visible");
     cy.findByText("Wed, Dec 14").should("exist");
     cy.findByText("all day").should("exist");
+  });
+
+  it("shows correct default time when uncreated event is changed to not be `allDay`", () => {
+    cy.visit("http://localhost:3000");
+
+    cy.get(`[aria-label="add event"]`).click();
+    cy.contains("label", "Title").click().type("Bye");
+    cy.contains("label", "Description").click().type("It's a beautiful night");
+    cy.contains("label", "Start Date").click().type("2022-12-14");
+    cy.contains("label", "End Date").click().type("2022-12-14");
+    cy.contains("label", "All Day").click();
+
+    cy.contains("label", "Start Time").should("not.exist");
+    cy.contains("label", "End Time").should("not.exist");
+
+    cy.contains("label", "All Day").click();
+
+    cy.get(`[id="startTime"]`).should("have.value", "03:12");
+    cy.get(`[id="endTime"]`).should("have.value", "04:12");
+    cy.contains("button", "Create Event").click();
   });
 
   describe("month view", () => {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -8,11 +8,13 @@ import FullCalendar, {
 import {
   formatDate,
   getDateTimeString,
-  padNumberWith0Zero,
   formatTime,
   modalDateFormat,
   addDayToAllDayEvent,
   formatDateMinusOneDay,
+  DEFAULT_START_TIME,
+  DEFAULT_END_TIME,
+  DEFAULT_DATE,
 } from "./lib";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
@@ -75,18 +77,9 @@ interface FormEntryProps {
 }
 
 const App = () => {
-  const currentHour: number = new Date().getHours();
-  const currentMinute: number = new Date().getMinutes();
-  const DEFAULT_START_TIME: string = `${padNumberWith0Zero(
-    currentHour
-  )}:${padNumberWith0Zero(currentMinute)}`;
-  const DEFAULT_END_TIME: string = `${padNumberWith0Zero(
-    currentHour + 1
-  )}:${padNumberWith0Zero(currentMinute)}`;
-  const DEFAULT_DATE = formatDate(new Date());
   const [events, setEvents] = useState<EventSourceInput>([]);
   const [displayedEventData, setDisplayedEventData] = useState(
-    {} as DisplayedEventData
+    {} as DisplayedEventData,
   );
   const [showOverlay, setShowOverlay] = useState<boolean>(false);
   const [inEditMode, setInEditMode] = useState<boolean>(false);
@@ -346,13 +339,13 @@ const App = () => {
                     initialTitle={displayedEventData.title}
                     initialDescription={displayedEventData.description}
                     initialStartDate={formatDate(
-                      new Date(displayedEventData.startTimeUtc)
+                      new Date(displayedEventData.startTimeUtc),
                     )}
                     initialEndDate={formatDate(
-                      new Date(displayedEventData.endTimeUtc)
+                      new Date(displayedEventData.endTimeUtc),
                     )}
                     initialStartTime={formatTime(
-                      displayedEventData.startTimeUtc
+                      displayedEventData.startTimeUtc,
                     )}
                     initialEndTime={formatTime(displayedEventData.endTimeUtc)}
                     initialAllDay={displayedEventData.allDay}

--- a/ui/src/EventForm.test.tsx
+++ b/ui/src/EventForm.test.tsx
@@ -1,14 +1,8 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React from "react";
 
 import userEvent from "@testing-library/user-event";
-import {
-  dateFormat,
-  formatDate,
-  getDateTimeString,
-  oneYearLater,
-  padNumberWith0Zero,
-} from "./lib";
+import { formatDate, getDateTimeString, padNumberWith0Zero } from "./lib";
 import EventForm from "./EventForm";
 
 describe("EventForm", () => {
@@ -32,10 +26,10 @@ describe("EventForm", () => {
         initialStartDate={formatDate(new Date())}
         initialEndDate={formatDate(new Date())}
         initialStartTime={`${padNumberWith0Zero(
-          currentHour
+          currentHour,
         )}:${padNumberWith0Zero(currentMinute)}`}
         initialEndTime={`${padNumberWith0Zero(
-          currentHour + 1
+          currentHour + 1,
         )}:${padNumberWith0Zero(currentMinute)}`}
         initialTitle="Mary's Chicken Feast"
         initialDescription="A time to remember and appreciate chicken nuggets and more"
@@ -43,7 +37,7 @@ describe("EventForm", () => {
         initialRecurring={false}
         onFormSubmit={() => {}}
         isCreate={true}
-      />
+      />,
     );
 
     expect(screen.getByLabelText("Start Date")).toHaveValue("2022-02-15");
@@ -52,7 +46,7 @@ describe("EventForm", () => {
     expect(screen.getByLabelText("End Time")).toHaveValue("05:00");
     expect(screen.getByLabelText("Title")).toHaveValue("Mary's Chicken Feast");
     expect(screen.getByLabelText("Description")).toHaveValue(
-      "A time to remember and appreciate chicken nuggets and more"
+      "A time to remember and appreciate chicken nuggets and more",
     );
     expect(screen.getByLabelText("All Day")).not.toBeChecked();
     expect(screen.getByLabelText("Recurring")).not.toBeChecked();
@@ -65,10 +59,10 @@ describe("EventForm", () => {
         initialStartDate={formatDate(new Date())}
         initialEndDate={formatDate(new Date())}
         initialStartTime={`${padNumberWith0Zero(
-          currentHour
+          currentHour,
         )}:${padNumberWith0Zero(currentMinute)}`}
         initialEndTime={`${padNumberWith0Zero(
-          currentHour + 1
+          currentHour + 1,
         )}:${padNumberWith0Zero(currentMinute)}`}
         initialTitle="Arty party"
         initialDescription="A time to remember and appreciate classic art and more"
@@ -76,7 +70,7 @@ describe("EventForm", () => {
         initialRecurring={false}
         onFormSubmit={() => {}}
         isCreate={false}
-      />
+      />,
     );
 
     expect(screen.getByRole("button")).toHaveAccessibleName("Save");
@@ -89,10 +83,10 @@ describe("EventForm", () => {
         initialStartDate={formatDate(new Date())}
         initialEndDate={formatDate(new Date())}
         initialStartTime={`${padNumberWith0Zero(
-          currentHour
+          currentHour,
         )}:${padNumberWith0Zero(currentMinute)}`}
         initialEndTime={`${padNumberWith0Zero(
-          currentHour + 1
+          currentHour + 1,
         )}:${padNumberWith0Zero(currentMinute)}`}
         initialTitle="Arty party"
         initialDescription="A time to remember and appreciate classic art and more"
@@ -100,7 +94,7 @@ describe("EventForm", () => {
         initialRecurring={false}
         onFormSubmit={onFormSubmitMock}
         isCreate={false}
-      />
+      />,
     );
 
     userEvent.click(screen.getByRole("button"));
@@ -123,10 +117,10 @@ describe("EventForm", () => {
         initialStartDate={formatDate(new Date())}
         initialEndDate={formatDate(new Date())}
         initialStartTime={`${padNumberWith0Zero(
-          currentHour
+          currentHour,
         )}:${padNumberWith0Zero(currentMinute)}`}
         initialEndTime={`${padNumberWith0Zero(
-          currentHour + 1
+          currentHour + 1,
         )}:${padNumberWith0Zero(currentMinute)}`}
         initialTitle="Arty party"
         initialDescription="A time to remember and appreciate classic art and more"
@@ -134,7 +128,7 @@ describe("EventForm", () => {
         initialRecurring={true}
         onFormSubmit={onFormSubmitMock}
         isCreate={false}
-      />
+      />,
     );
 
     userEvent.click(screen.getByRole("button"));
@@ -160,10 +154,10 @@ describe("EventForm", () => {
         initialStartDate={formatDate(new Date())}
         initialEndDate={formatDate(new Date())}
         initialStartTime={`${padNumberWith0Zero(
-          currentHour
+          currentHour,
         )}:${padNumberWith0Zero(currentMinute)}`}
         initialEndTime={`${padNumberWith0Zero(
-          currentHour + 1
+          currentHour + 1,
         )}:${padNumberWith0Zero(currentMinute)}`}
         initialTitle=""
         initialDescription="A time to remember and appreciate classic art and more"
@@ -171,7 +165,7 @@ describe("EventForm", () => {
         initialRecurring={false}
         onFormSubmit={onFormSubmitMock}
         isCreate={false}
-      />
+      />,
     );
     userEvent.click(screen.getByRole("button"));
     expect(screen.getByText("Error: title cannot be empty.")).toBeVisible();
@@ -183,10 +177,10 @@ describe("EventForm", () => {
         initialStartDate={formatDate(new Date())}
         initialEndDate={formatDate(new Date())}
         initialStartTime={`${padNumberWith0Zero(
-          currentHour
+          currentHour,
         )}:${padNumberWith0Zero(currentMinute)}`}
         initialEndTime={`${padNumberWith0Zero(
-          currentHour + 1
+          currentHour + 1,
         )}:${padNumberWith0Zero(currentMinute)}`}
         initialTitle="Arty party"
         initialDescription="A time to remember and appreciate classic art and more"
@@ -194,7 +188,7 @@ describe("EventForm", () => {
         initialRecurring={false}
         onFormSubmit={() => {}}
         isCreate={false}
-      />
+      />,
     );
     expect(screen.getByLabelText("All Day")).toBeChecked();
     expect(screen.queryByLabelText("Start Time")).not.toBeInTheDocument();
@@ -209,7 +203,7 @@ describe("EventForm", () => {
   it("displays recurring defaults when recurring is selected", () => {
     const startDate = formatDate(new Date());
     const startTime = `${padNumberWith0Zero(currentHour)}:${padNumberWith0Zero(
-      currentMinute
+      currentMinute,
     )}`;
     render(
       <EventForm
@@ -217,7 +211,7 @@ describe("EventForm", () => {
         initialEndDate={startDate}
         initialStartTime={startTime}
         initialEndTime={`${padNumberWith0Zero(
-          currentHour + 1
+          currentHour + 1,
         )}:${padNumberWith0Zero(currentMinute)}`}
         initialTitle="Mary's Chicken Feast"
         initialDescription="A time to remember and appreciate chicken nuggets and more"
@@ -225,22 +219,22 @@ describe("EventForm", () => {
         initialRecurring={true}
         onFormSubmit={() => {}}
         isCreate={true}
-      />
+      />,
     );
 
     expect(screen.getByText("Recurrence Frequency")).toBeVisible();
     expect(
-      screen.getByText("Recurrence begins: Tue, Feb 15 2022, 04:00 AM")
+      screen.getByText("Recurrence begins: Tue, Feb 15 2022, 04:00 AM"),
     ).toBeVisible();
     expect(
-      screen.getByText("Recurrence ends: Wed, Feb 15 2023, 04:00 AM")
+      screen.getByText("Recurrence ends: Wed, Feb 15 2023, 04:00 AM"),
     ).toBeVisible();
   });
 
   it("allows user to choose between monthly and weekly recurrence", () => {
     const startDate = formatDate(new Date());
     const startTime = `${padNumberWith0Zero(currentHour)}:${padNumberWith0Zero(
-      currentMinute
+      currentMinute,
     )}`;
     render(
       <EventForm
@@ -248,7 +242,7 @@ describe("EventForm", () => {
         initialEndDate={startDate}
         initialStartTime={startTime}
         initialEndTime={`${padNumberWith0Zero(
-          currentHour + 1
+          currentHour + 1,
         )}:${padNumberWith0Zero(currentMinute)}`}
         initialTitle="Mary's Chicken Feast"
         initialDescription="A time to remember and appreciate chicken nuggets and more"
@@ -256,7 +250,7 @@ describe("EventForm", () => {
         initialRecurring={true}
         onFormSubmit={() => {}}
         isCreate={true}
-      />
+      />,
     );
 
     expect(screen.getByText("Monthly")).toBeVisible();

--- a/ui/src/EventForm.tsx
+++ b/ui/src/EventForm.tsx
@@ -4,6 +4,8 @@ import {
   getDateTimeString,
   oneYearLater,
   singleModalDateFormat,
+  DEFAULT_START_TIME,
+  DEFAULT_END_TIME,
 } from "./lib";
 import { Checkbox, RadioGroup, Radio, Stack } from "@chakra-ui/react";
 import s from "./EventForm.module.css";
@@ -144,6 +146,8 @@ const EventForm = ({
           isChecked={allDay}
           onChange={(e) => {
             setAllDay(e.target.checked);
+            setStartTime(DEFAULT_START_TIME);
+            setEndTime(DEFAULT_END_TIME);
           }}
         >
           All Day

--- a/ui/src/EventForm.tsx
+++ b/ui/src/EventForm.tsx
@@ -146,8 +146,10 @@ const EventForm = ({
           isChecked={allDay}
           onChange={(e) => {
             setAllDay(e.target.checked);
-            setStartTime(DEFAULT_START_TIME);
-            setEndTime(DEFAULT_END_TIME);
+            if(e.target.checked === false) {
+              setStartTime(DEFAULT_START_TIME);
+              setEndTime(DEFAULT_END_TIME);
+            }
           }}
         >
           All Day

--- a/ui/src/lib.ts
+++ b/ui/src/lib.ts
@@ -99,6 +99,19 @@ const addDayToAllDayEvent: EventInputTransformer = (event: EventInput) => {
   return event;
 };
 
+const currentHour: number = new Date().getHours();
+const currentMinute: number = new Date().getMinutes();
+
+const DEFAULT_START_TIME: string = `${padNumberWith0Zero(
+  currentHour,
+)}:${padNumberWith0Zero(currentMinute)}`;
+
+const DEFAULT_END_TIME: string = `${padNumberWith0Zero(
+  currentHour + 1,
+)}:${padNumberWith0Zero(currentMinute)}`;
+
+const DEFAULT_DATE = formatDate(new Date());
+
 export {
   addDayToAllDayEvent,
   formatDate,
@@ -112,4 +125,7 @@ export {
   oneYearLater,
   singleModalDateFormat,
   dateFormatWithYear,
+  DEFAULT_START_TIME,
+  DEFAULT_END_TIME,
+  DEFAULT_DATE,
 };

--- a/ui/src/lib.ts
+++ b/ui/src/lib.ts
@@ -100,15 +100,10 @@ const addDayToAllDayEvent: EventInputTransformer = (event: EventInput) => {
 };
 
 const currentHour: number = new Date().getHours();
-const currentMinute: number = new Date().getMinutes();
 
-const DEFAULT_START_TIME: string = `${padNumberWith0Zero(
-  currentHour,
-)}:${padNumberWith0Zero(currentMinute)}`;
+const DEFAULT_START_TIME: string = `${padNumberWith0Zero(currentHour + 1)}:00`;
 
-const DEFAULT_END_TIME: string = `${padNumberWith0Zero(
-  currentHour + 1,
-)}:${padNumberWith0Zero(currentMinute)}`;
+const DEFAULT_END_TIME: string = `${padNumberWith0Zero(currentHour + 2)}:00`;
 
 const DEFAULT_DATE = formatDate(new Date());
 

--- a/ui/src/lib.ts
+++ b/ui/src/lib.ts
@@ -102,9 +102,7 @@ const addDayToAllDayEvent: EventInputTransformer = (event: EventInput) => {
 const currentHour: number = new Date().getHours();
 
 const DEFAULT_START_TIME: string = `${padNumberWith0Zero(currentHour + 1)}:00`;
-
 const DEFAULT_END_TIME: string = `${padNumberWith0Zero(currentHour + 2)}:00`;
-
 const DEFAULT_DATE = formatDate(new Date());
 
 export {


### PR DESCRIPTION
_Closes:_ #101 

## Summary of changes
When allDay is unchecked, use the default time
Update default time to be rounded to the next hour
Moves reused consts into `lib`

## Dev notes
Was having trouble with date mock being applied on EventForm unit tests, so just wrote cypress tests


## Testing
- [x] Unit tests
2 failing frontend tests from main which are resolved in separate PR

#### Screenshot of UI (local testing in browser)
![image](https://user-images.githubusercontent.com/31298051/210023637-6cfefe8c-d4dc-46b7-b060-4f711b085495.png)
