### PR TITLE
Fix test warning

### DIFF
--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -316,18 +316,16 @@ describe("App", () => {
   describe("Backend interaction errors", () => {
     it("getEntries error displays error message", async () => {
       mockGetEntries.mockRejectedValue("Error in getEntry");
-      await act(async () => {
-        await render(<App />);
-      });
+      render(<App />);
+
       expect(await screen.findByRole("alert")).toBeVisible();
     });
 
     it("createEntry error displays error message", async () => {
       mockGetEntries.mockResolvedValue([]);
       mockCreateEntry.mockRejectedValue("Error in createEntry");
-      await act(async () => {
-        await render(<App />);
-      });
+      render(<App />);
+
       userEvent.click(screen.getByLabelText("add event"));
       userEvent.click(screen.getByLabelText("Title"));
       userEvent.type(
@@ -360,9 +358,8 @@ describe("App", () => {
       ]);
 
       mockGetEntry.mockRejectedValue("Error in getEntry");
-      await act(async () => {
-        await render(<App />);
-      });
+      render(<App />);
+
       const eventText = await screen.findByText("Dance");
       expect(eventText).toBeInTheDocument();
       await act(async () => {
@@ -371,7 +368,6 @@ describe("App", () => {
       expect(await screen.findByRole("alert")).toBeVisible();
     });
 
-    // TODO: Fix 'A component is changing an uncontrolled input to be controlled' error
     it("updateEntry displays an error message", async () => {
       mockGetEntries.mockResolvedValueOnce([
         {
@@ -391,9 +387,7 @@ describe("App", () => {
 
       mockUpdateEntry.mockRejectedValue("Error in updateEntry");
 
-      await act(async () => {
-        await render(<App />);
-      });
+      render(<App />);
 
       const eventText = await screen.findByText("Dance");
       expect(eventText).toBeInTheDocument();
@@ -410,7 +404,7 @@ describe("App", () => {
 
       userEvent.click(screen.getByText("Save"));
       expect(await screen.findByRole("alert")).toBeVisible();
-    }, 20000);
+    });
 
     it("deleteEntry displays an error message", async () => {
       mockGetEntries.mockResolvedValueOnce([
@@ -447,9 +441,8 @@ describe("App", () => {
 
       mockDeleteEntry.mockRejectedValue("Error in deleteEntry");
 
-      await act(async () => {
-        await render(<App />);
-      });
+      render(<App />);
+
       expect(mockGetEntries).toHaveBeenCalledTimes(1);
       const eventText = await screen.findByText("Dance");
       expect(eventText).toBeInTheDocument();

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -79,7 +79,9 @@ interface FormEntryProps {
 const App = () => {
   const currentHour: number = new Date().getHours();
 
-  const DEFAULT_START_TIME: string = `${padNumberWith0Zero(currentHour + 1)}:00`;
+  const DEFAULT_START_TIME: string = `${padNumberWith0Zero(
+    currentHour + 1,
+  )}:00`;
   const DEFAULT_END_TIME: string = `${padNumberWith0Zero(currentHour + 2)}:00`;
   const DEFAULT_DATE = formatDate(new Date());
 

--- a/ui/src/EventForm.tsx
+++ b/ui/src/EventForm.tsx
@@ -23,7 +23,7 @@ const EventForm = ({
   initialStartTime,
   initialEndTime,
   initialTitle,
-  initialDescription,
+  initialDescription = "",
   initialAllDay,
   initialRecurring,
   initialRecurrenceEnd,
@@ -38,9 +38,7 @@ const EventForm = ({
   const [title, setTitle] = useState<string>(initialTitle);
   // `|| ""` prevents warning in tests
   // "Warning: A component is changing an uncontrolled input of type text to be controlled."
-  const [description, setDescription] = useState<string>(
-    initialDescription || "",
-  );
+  const [description, setDescription] = useState<string>(initialDescription);
   const [allDay, setAllDay] = useState<boolean>(initialAllDay);
   const [recurring, setRecurring] = useState<boolean>(initialRecurring);
   const [recurrenceFrequency, setRecurrenceFrequency] =

--- a/ui/src/EventForm.tsx
+++ b/ui/src/EventForm.tsx
@@ -1,9 +1,5 @@
 import React, { useState } from "react";
-import {
-  formatDate,
-  getDateTimeString,
-  padNumberWith0Zero,
-} from "./lib";
+import { formatDate, getDateTimeString, padNumberWith0Zero } from "./lib";
 import { Checkbox, RadioGroup, Radio, Stack } from "@chakra-ui/react";
 import s from "./EventForm.module.css";
 
@@ -40,7 +36,11 @@ const EventForm = ({
   const [endTime, setEndTime] = useState<string>(initialEndTime);
   const [error, setError] = useState<string | null>(null);
   const [title, setTitle] = useState<string>(initialTitle);
-  const [description, setDescription] = useState<string>(initialDescription);
+  // `|| ""` prevents warning in tests
+  // "Warning: A component is changing an uncontrolled input of type text to be controlled."
+  const [description, setDescription] = useState<string>(
+    initialDescription || "",
+  );
   const [allDay, setAllDay] = useState<boolean>(initialAllDay);
   const [recurring, setRecurring] = useState<boolean>(initialRecurring);
   const [recurrenceFrequency, setRecurrenceFrequency] =
@@ -48,7 +48,9 @@ const EventForm = ({
 
   const currentHour: number = new Date().getHours();
 
-  const DEFAULT_START_TIME: string = `${padNumberWith0Zero(currentHour + 1)}:00`;
+  const DEFAULT_START_TIME: string = `${padNumberWith0Zero(
+    currentHour + 1,
+  )}:00`;
   const DEFAULT_END_TIME: string = `${padNumberWith0Zero(currentHour + 2)}:00`;
 
   const recurrenceBeginDate = new Date(getDateTimeString(startDate, startTime));


### PR DESCRIPTION
_Closes:_ N/A

## Summary of changes
Fix warning that delays tests:
> Warning: A component is changing an uncontrolled input of type text to be controlled. 

- Prettier
- Simplify renders
- Add `|| ""` to EventForm description field (somehow that stopped the warning and makes the tests run twice as fast)

## Dev notes

## Testing

- [ ] Unit tests

#### Screenshot of UI (local testing in browser)
![image](https://user-images.githubusercontent.com/31298051/210715195-8adf8e5d-e5ce-4fca-a35a-e995a0541498.png)
