### PR TITLE
Simplify date handling (Cal 113 default time bug)

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -6,12 +6,13 @@ import FullCalendar, {
   EventSourceInput,
 } from "@fullcalendar/react";
 import {
-  formatDate,
-  modalDateFormat,
   addDayToAllDayEvent,
-  oneYearLater,
   dateMinusOneDay,
+  datePlusHours,
+  formatDate,
   getDateTimeString,
+  modalDateFormat,
+  oneYearLater,
 } from "./lib";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
@@ -75,11 +76,6 @@ interface FormEntryProps {
 }
 
 const App = () => {
-  const datePlusHours: Function = (date: Date, hours: number): Date => {
-    date.setHours(date.getHours() + hours);
-    return date;
-  };
-
   const DEFAULT_START = datePlusHours(new Date(), 1).toISOString();
   const DEFAULT_END = datePlusHours(new Date(), 2).toISOString();
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -14,6 +14,7 @@ import {
   formatDateMinusOneDay,
   oneYearLater,
   padNumberWith0Zero,
+  dateMinusOneDay,
 } from "./lib";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
@@ -77,13 +78,21 @@ interface FormEntryProps {
 }
 
 const App = () => {
-  const currentHour: number = new Date().getHours();
+  // const currentHour: number = new Date().getHours();
 
-  const DEFAULT_START_TIME: string = `${padNumberWith0Zero(
-    currentHour + 1,
-  )}:00`;
-  const DEFAULT_END_TIME: string = `${padNumberWith0Zero(currentHour + 2)}:00`;
-  const DEFAULT_DATE = formatDate(new Date());
+  // const DEFAULT_START_TIME: string = `${padNumberWith0Zero(
+  //   currentHour + 1,
+  // )}:00`;
+  // const DEFAULT_END_TIME: string = `${padNumberWith0Zero(currentHour + 2)}:00`;
+  // const DEFAULT_DATE = formatDate(new Date());
+
+  const datePlusHours: Function = (date: Date, hours: number): Date => {
+    date.setHours(date.getHours() + hours);
+    return date;
+  };
+
+  const DEFAULT_START = formatDate(datePlusHours(new Date(), 1));
+  const DEFAULT_END = formatDate(datePlusHours(new Date(), 2));
 
   const [events, setEvents] = useState<EventSourceInput>([]);
   const [displayedEventData, setDisplayedEventData] = useState(
@@ -92,11 +101,11 @@ const App = () => {
   const [showOverlay, setShowOverlay] = useState<boolean>(false);
   const [inEditMode, setInEditMode] = useState<boolean>(false);
   const [inCreateMode, setInCreateMode] = useState<boolean>(false);
-  const [modalStartDate, setModalStartDate] = useState<string>("");
-  const [modalEndDate, setModalEndDate] = useState<string>("");
-  const [modalStartTime, setModalStartTime] =
-    useState<string>(DEFAULT_START_TIME);
-  const [modalEndTime, setModalEndTime] = useState<string>(DEFAULT_END_TIME);
+  // const [modalStartDate, setModalStartDate] = useState<string>("");
+  // const [modalEndDate, setModalEndDate] = useState<string>("");
+  // const [modalStartTime, setModalStartTime] =
+  //   useState<string>(DEFAULT_START_TIME);
+  // const [modalEndTime, setModalEndTime] = useState<string>(DEFAULT_END_TIME);
 
   const [modalStart, setModalStart] = useState<string>(formatDate(new Date()));
   const [modalEnd, setModalEnd] = useState<string>(formatDate(new Date()));
@@ -268,10 +277,12 @@ const App = () => {
                     size="lg"
                     icon={<AddIcon boxSize={7} w={7} h={7} />}
                     onClick={() => {
-                      setModalStartDate(DEFAULT_DATE);
-                      setModalEndDate(DEFAULT_DATE);
-                      setModalStartTime(DEFAULT_START_TIME);
-                      setModalEndTime(DEFAULT_END_TIME);
+                      // setModalStartDate(DEFAULT_DATE);
+                      // setModalEndDate(DEFAULT_DATE);
+                      // setModalStartTime(DEFAULT_START_TIME);
+                      // setModalEndTime(DEFAULT_END_TIME);
+                      setModalStart(DEFAULT_START);
+                      setModalEnd(DEFAULT_END);
                       setInCreateMode(true);
                       setShowOverlay(true);
                     }}
@@ -297,15 +308,19 @@ const App = () => {
                 select={({ start, end, allDay }) => {
                   setModalAllDay(allDay);
 
-                  setModalStartDate(formatDate(start));
+                  // setModalStartDate(formatDate(start));
+                  setModalStart(start.toISOString());
+
                   if (allDay) {
-                    setModalEndDate(formatDateMinusOneDay(end));
+                    // setModalEndDate(formatDateMinusOneDay(end));
+                    setModalEnd(dateMinusOneDay(end).toISOString());
                   } else {
-                    setModalEndDate(formatDate(end));
+                    // setModalEndDate(formatDate(end));
+                    setModalEnd(end.toISOString());
                   }
 
-                  setModalStartTime(formatTime(start.toUTCString()));
-                  setModalEndTime(formatTime(end.toUTCString()));
+                  // setModalStartTime(formatTime(start.toUTCString()));
+                  // setModalEndTime(formatTime(end.toUTCString()));
 
                   setInCreateMode(true);
                   setShowOverlay(true);
@@ -358,16 +373,6 @@ const App = () => {
                   <EventForm
                     initialTitle={displayedEventData.title}
                     initialDescription={displayedEventData.description}
-                    initialStartDate={formatDate(
-                      new Date(displayedEventData.startTimeUtc),
-                    )}
-                    initialEndDate={formatDate(
-                      new Date(displayedEventData.endTimeUtc),
-                    )}
-                    initialStartTime={formatTime(
-                      displayedEventData.startTimeUtc,
-                    )}
-                    initialEndTime={formatTime(displayedEventData.endTimeUtc)}
                     initialStart={displayedEventData.startTimeUtc}
                     initialEnd={displayedEventData.endTimeUtc}
                     initialAllDay={displayedEventData.allDay}
@@ -389,17 +394,15 @@ const App = () => {
                   <EventForm
                     initialTitle=""
                     initialDescription=""
-                    initialStartDate={modalStartDate}
-                    initialEndDate={modalEndDate}
-                    initialStartTime={modalStartTime}
-                    initialEndTime={modalEndTime}
-                    initialStart={displayedEventData.startTimeUtc}
-                    initialEnd={displayedEventData.endTimeUtc}
+                    // initialStartDate={modalStartDate}
+                    // initialEndDate={modalEndDate}
+                    // initialStartTime={modalStartTime}
+                    // initialEndTime={modalEndTime}
+                    initialStart={modalStart}
+                    initialEnd={modalEnd}
                     initialAllDay={modalAllDay}
                     initialRecurring={false}
-                    initialRecurrenceEnd={formatDate(
-                      oneYearLater(modalStartDate),
-                    )}
+                    initialRecurrenceEnd={formatDate(oneYearLater(modalStart))}
                     onFormSubmit={handleCreateEntry}
                     isCreate={true}
                   />

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -97,6 +97,10 @@ const App = () => {
   const [modalStartTime, setModalStartTime] =
     useState<string>(DEFAULT_START_TIME);
   const [modalEndTime, setModalEndTime] = useState<string>(DEFAULT_END_TIME);
+
+  const [modalStart, setModalStart] = useState<string>(formatDate(new Date()));
+  const [modalEnd, setModalEnd] = useState<string>(formatDate(new Date()));
+
   const [modalAllDay, setModalAllDay] = useState<boolean>(false);
   const [apiError, setApiError] = useState<boolean>(false);
 
@@ -364,6 +368,8 @@ const App = () => {
                       displayedEventData.startTimeUtc,
                     )}
                     initialEndTime={formatTime(displayedEventData.endTimeUtc)}
+                    initialStart={displayedEventData.startTimeUtc}
+                    initialEnd={displayedEventData.endTimeUtc}
                     initialAllDay={displayedEventData.allDay}
                     initialRecurring={displayedEventData.recurring}
                     initialRecurrenceEnd={formatDate(
@@ -387,6 +393,8 @@ const App = () => {
                     initialEndDate={modalEndDate}
                     initialStartTime={modalStartTime}
                     initialEndTime={modalEndTime}
+                    initialStart={displayedEventData.startTimeUtc}
+                    initialEnd={displayedEventData.endTimeUtc}
                     initialAllDay={modalAllDay}
                     initialRecurring={false}
                     initialRecurrenceEnd={formatDate(

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -8,12 +8,9 @@ import FullCalendar, {
 import {
   formatDate,
   getDateTimeString,
-  formatTime,
   modalDateFormat,
   addDayToAllDayEvent,
-  formatDateMinusOneDay,
   oneYearLater,
-  padNumberWith0Zero,
   dateMinusOneDay,
 } from "./lib";
 import dayGridPlugin from "@fullcalendar/daygrid";
@@ -78,14 +75,6 @@ interface FormEntryProps {
 }
 
 const App = () => {
-  // const currentHour: number = new Date().getHours();
-
-  // const DEFAULT_START_TIME: string = `${padNumberWith0Zero(
-  //   currentHour + 1,
-  // )}:00`;
-  // const DEFAULT_END_TIME: string = `${padNumberWith0Zero(currentHour + 2)}:00`;
-  // const DEFAULT_DATE = formatDate(new Date());
-
   const datePlusHours: Function = (date: Date, hours: number): Date => {
     date.setHours(date.getHours() + hours);
     return date;
@@ -101,11 +90,6 @@ const App = () => {
   const [showOverlay, setShowOverlay] = useState<boolean>(false);
   const [inEditMode, setInEditMode] = useState<boolean>(false);
   const [inCreateMode, setInCreateMode] = useState<boolean>(false);
-  // const [modalStartDate, setModalStartDate] = useState<string>("");
-  // const [modalEndDate, setModalEndDate] = useState<string>("");
-  // const [modalStartTime, setModalStartTime] =
-  //   useState<string>(DEFAULT_START_TIME);
-  // const [modalEndTime, setModalEndTime] = useState<string>(DEFAULT_END_TIME);
 
   const [modalStart, setModalStart] = useState<string>(formatDate(new Date()));
   const [modalEnd, setModalEnd] = useState<string>(formatDate(new Date()));
@@ -277,10 +261,6 @@ const App = () => {
                     size="lg"
                     icon={<AddIcon boxSize={7} w={7} h={7} />}
                     onClick={() => {
-                      // setModalStartDate(DEFAULT_DATE);
-                      // setModalEndDate(DEFAULT_DATE);
-                      // setModalStartTime(DEFAULT_START_TIME);
-                      // setModalEndTime(DEFAULT_END_TIME);
                       setModalStart(DEFAULT_START);
                       setModalEnd(DEFAULT_END);
                       setInCreateMode(true);
@@ -307,20 +287,13 @@ const App = () => {
                 eventClick={openModal}
                 select={({ start, end, allDay }) => {
                   setModalAllDay(allDay);
-
-                  // setModalStartDate(formatDate(start));
                   setModalStart(start.toISOString());
 
                   if (allDay) {
-                    // setModalEndDate(formatDateMinusOneDay(end));
                     setModalEnd(dateMinusOneDay(end).toISOString());
                   } else {
-                    // setModalEndDate(formatDate(end));
                     setModalEnd(end.toISOString());
                   }
-
-                  // setModalStartTime(formatTime(start.toUTCString()));
-                  // setModalEndTime(formatTime(end.toUTCString()));
 
                   setInCreateMode(true);
                   setShowOverlay(true);

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -7,12 +7,11 @@ import FullCalendar, {
 } from "@fullcalendar/react";
 import {
   formatDate,
-  getDateTimeString,
   modalDateFormat,
   addDayToAllDayEvent,
   oneYearLater,
   dateMinusOneDay,
-  applyTimeToDate,
+  getDateTimeString,
 } from "./lib";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
@@ -92,10 +91,8 @@ const App = () => {
   const [inEditMode, setInEditMode] = useState<boolean>(false);
   const [inCreateMode, setInCreateMode] = useState<boolean>(false);
 
-  const [modalStart, setModalStart] = useState<string>(
-    new Date().toISOString(),
-  );
-  const [modalEnd, setModalEnd] = useState<string>(new Date().toISOString());
+  const [modalStart, setModalStart] = useState<string>(DEFAULT_START);
+  const [modalEnd, setModalEnd] = useState<string>(DEFAULT_END);
 
   const [modalAllDay, setModalAllDay] = useState<boolean>(false);
   const [apiError, setApiError] = useState<boolean>(false);
@@ -214,11 +211,11 @@ const App = () => {
     recurrenceEnds,
   }: FormEntryProps) => {
     const entryId = displayedEventData._id;
-    const startTimeUtc = new Date(applyTimeToDate(startDate, startTime));
-    const endTimeUtc = new Date(applyTimeToDate(endDate, endTime));
+    const startTimeUtc = new Date(getDateTimeString(startDate, startTime));
+    const endTimeUtc = new Date(getDateTimeString(endDate, endTime));
     let recurrenceEndUtc;
     if (recurrenceEnds) {
-      recurrenceEndUtc = new Date(applyTimeToDate(recurrenceEnds, startTime));
+      recurrenceEndUtc = new Date(getDateTimeString(recurrenceEnds, startTime));
     }
 
     updateEntry(entryId, {
@@ -374,7 +371,9 @@ const App = () => {
                     initialEnd={modalEnd}
                     initialAllDay={modalAllDay}
                     initialRecurring={false}
-                    initialRecurrenceEnd={formatDate(oneYearLater(modalStart))}
+                    initialRecurrenceEnd={oneYearLater(
+                      modalStart,
+                    ).toISOString()}
                     onFormSubmit={handleCreateEntry}
                     isCreate={true}
                   />

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -12,6 +12,7 @@ import {
   addDayToAllDayEvent,
   oneYearLater,
   dateMinusOneDay,
+  applyTimeToDate,
 } from "./lib";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
@@ -80,8 +81,8 @@ const App = () => {
     return date;
   };
 
-  const DEFAULT_START = formatDate(datePlusHours(new Date(), 1));
-  const DEFAULT_END = formatDate(datePlusHours(new Date(), 2));
+  const DEFAULT_START = datePlusHours(new Date(), 1).toISOString();
+  const DEFAULT_END = datePlusHours(new Date(), 2).toISOString();
 
   const [events, setEvents] = useState<EventSourceInput>([]);
   const [displayedEventData, setDisplayedEventData] = useState(
@@ -91,8 +92,10 @@ const App = () => {
   const [inEditMode, setInEditMode] = useState<boolean>(false);
   const [inCreateMode, setInCreateMode] = useState<boolean>(false);
 
-  const [modalStart, setModalStart] = useState<string>(formatDate(new Date()));
-  const [modalEnd, setModalEnd] = useState<string>(formatDate(new Date()));
+  const [modalStart, setModalStart] = useState<string>(
+    new Date().toISOString(),
+  );
+  const [modalEnd, setModalEnd] = useState<string>(new Date().toISOString());
 
   const [modalAllDay, setModalAllDay] = useState<boolean>(false);
   const [apiError, setApiError] = useState<boolean>(false);
@@ -211,11 +214,11 @@ const App = () => {
     recurrenceEnds,
   }: FormEntryProps) => {
     const entryId = displayedEventData._id;
-    const startTimeUtc = new Date(getDateTimeString(startDate, startTime));
-    const endTimeUtc = new Date(getDateTimeString(endDate, endTime));
+    const startTimeUtc = new Date(applyTimeToDate(startDate, startTime));
+    const endTimeUtc = new Date(applyTimeToDate(endDate, endTime));
     let recurrenceEndUtc;
     if (recurrenceEnds) {
-      recurrenceEndUtc = new Date(getDateTimeString(recurrenceEnds, startTime));
+      recurrenceEndUtc = new Date(applyTimeToDate(recurrenceEnds, startTime));
     }
 
     updateEntry(entryId, {
@@ -367,10 +370,6 @@ const App = () => {
                   <EventForm
                     initialTitle=""
                     initialDescription=""
-                    // initialStartDate={modalStartDate}
-                    // initialEndDate={modalEndDate}
-                    // initialStartTime={modalStartTime}
-                    // initialEndTime={modalEndTime}
                     initialStart={modalStart}
                     initialEnd={modalEnd}
                     initialAllDay={modalAllDay}

--- a/ui/src/EventForm.test.tsx
+++ b/ui/src/EventForm.test.tsx
@@ -31,6 +31,8 @@ describe("EventForm", () => {
         initialEndTime={`${padNumberWith0Zero(
           currentHour + 1,
         )}:${padNumberWith0Zero(currentMinute)}`}
+        initialStart={formatDate(new Date())}
+        initialEnd={formatDate(new Date())}
         initialTitle="Mary's Chicken Feast"
         initialDescription="A time to remember and appreciate chicken nuggets and more"
         initialAllDay={false}
@@ -66,6 +68,8 @@ describe("EventForm", () => {
         initialEndTime={`${padNumberWith0Zero(
           currentHour + 1,
         )}:${padNumberWith0Zero(currentMinute)}`}
+        initialStart={formatDate(new Date())}
+        initialEnd={formatDate(new Date())}
         initialTitle="Arty party"
         initialDescription="A time to remember and appreciate classic art and more"
         initialAllDay={false}
@@ -91,6 +95,8 @@ describe("EventForm", () => {
         initialEndTime={`${padNumberWith0Zero(
           currentHour + 1,
         )}:${padNumberWith0Zero(currentMinute)}`}
+        initialStart={formatDate(new Date())}
+        initialEnd={formatDate(new Date())}
         initialTitle="Arty party"
         initialDescription="A time to remember and appreciate classic art and more"
         initialAllDay={false}
@@ -126,6 +132,8 @@ describe("EventForm", () => {
         initialEndTime={`${padNumberWith0Zero(
           currentHour + 1,
         )}:${padNumberWith0Zero(currentMinute)}`}
+        initialStart={formatDate(new Date())}
+        initialEnd={formatDate(new Date())}
         initialTitle=""
         initialDescription="A time to remember and appreciate classic art and more"
         initialAllDay={false}
@@ -150,6 +158,8 @@ describe("EventForm", () => {
         initialEndTime={`${padNumberWith0Zero(
           currentHour + 1,
         )}:${padNumberWith0Zero(currentMinute)}`}
+        initialStart={formatDate(new Date())}
+        initialEnd={formatDate(new Date())}
         initialTitle="Arty party"
         initialDescription="A time to remember and appreciate classic art and more"
         initialAllDay={true}
@@ -182,6 +192,8 @@ describe("EventForm", () => {
           initialEndTime={`${padNumberWith0Zero(
             currentHour + 1,
           )}:${padNumberWith0Zero(currentMinute)}`}
+          initialStart={formatDate(new Date())}
+          initialEnd={formatDate(new Date())}
           initialTitle="Arty party"
           initialDescription="A time to remember and appreciate classic art and more"
           initialAllDay={false}
@@ -221,6 +233,8 @@ describe("EventForm", () => {
           initialEndTime={`${padNumberWith0Zero(
             currentHour + 1,
           )}:${padNumberWith0Zero(currentMinute)}`}
+          initialStart={formatDate(new Date())}
+          initialEnd={formatDate(new Date())}
           initialTitle="Mary's Chicken Feast"
           initialDescription="A time to remember and appreciate chicken nuggets and more"
           initialAllDay={false}
@@ -250,6 +264,8 @@ describe("EventForm", () => {
           initialEndTime={`${padNumberWith0Zero(
             currentHour + 1,
           )}:${padNumberWith0Zero(currentMinute)}`}
+          initialStart={formatDate(new Date())}
+          initialEnd={formatDate(new Date())}
           initialTitle="Mary's Chicken Feast"
           initialDescription="A time to remember and appreciate chicken nuggets and more"
           initialAllDay={false}

--- a/ui/src/EventForm.test.tsx
+++ b/ui/src/EventForm.test.tsx
@@ -21,18 +21,14 @@ describe("EventForm", () => {
   });
 
   it("displays initial values", () => {
+    const datePlusHours: Function = (date: Date, hours: number): Date => {
+      date.setHours(date.getHours() + hours);
+      return date;
+    };
     render(
       <EventForm
-        initialStartDate={formatDate(new Date())}
-        initialEndDate={formatDate(new Date())}
-        initialStartTime={`${padNumberWith0Zero(
-          currentHour,
-        )}:${padNumberWith0Zero(currentMinute)}`}
-        initialEndTime={`${padNumberWith0Zero(
-          currentHour + 1,
-        )}:${padNumberWith0Zero(currentMinute)}`}
         initialStart={formatDate(new Date())}
-        initialEnd={formatDate(new Date())}
+        initialEnd={formatDate(datePlusHours(new Date(), 1))}
         initialTitle="Mary's Chicken Feast"
         initialDescription="A time to remember and appreciate chicken nuggets and more"
         initialAllDay={false}
@@ -60,16 +56,8 @@ describe("EventForm", () => {
   it("displays `Save` button when `isCreate` is false", () => {
     render(
       <EventForm
-        initialStartDate={formatDate(new Date())}
-        initialEndDate={formatDate(new Date())}
-        initialStartTime={`${padNumberWith0Zero(
-          currentHour,
-        )}:${padNumberWith0Zero(currentMinute)}`}
-        initialEndTime={`${padNumberWith0Zero(
-          currentHour + 1,
-        )}:${padNumberWith0Zero(currentMinute)}`}
-        initialStart={formatDate(new Date())}
-        initialEnd={formatDate(new Date())}
+        initialStart={formatDate(new Date("2022-02-15T04:00"))}
+        initialEnd={formatDate(new Date("2022-02-15T05:00"))}
         initialTitle="Arty party"
         initialDescription="A time to remember and appreciate classic art and more"
         initialAllDay={false}
@@ -87,16 +75,8 @@ describe("EventForm", () => {
     const onFormSubmitMock = jest.fn();
     render(
       <EventForm
-        initialStartDate={formatDate(new Date())}
-        initialEndDate={formatDate(new Date())}
-        initialStartTime={`${padNumberWith0Zero(
-          currentHour,
-        )}:${padNumberWith0Zero(currentMinute)}`}
-        initialEndTime={`${padNumberWith0Zero(
-          currentHour + 1,
-        )}:${padNumberWith0Zero(currentMinute)}`}
-        initialStart={formatDate(new Date())}
-        initialEnd={formatDate(new Date())}
+        initialStart={formatDate(new Date("2022-02-15T04:00"))}
+        initialEnd={formatDate(new Date("2022-02-15T05:00"))}
         initialTitle="Arty party"
         initialDescription="A time to remember and appreciate classic art and more"
         initialAllDay={false}
@@ -124,16 +104,8 @@ describe("EventForm", () => {
     const onFormSubmitMock = jest.fn();
     render(
       <EventForm
-        initialStartDate={formatDate(new Date())}
-        initialEndDate={formatDate(new Date())}
-        initialStartTime={`${padNumberWith0Zero(
-          currentHour,
-        )}:${padNumberWith0Zero(currentMinute)}`}
-        initialEndTime={`${padNumberWith0Zero(
-          currentHour + 1,
-        )}:${padNumberWith0Zero(currentMinute)}`}
-        initialStart={formatDate(new Date())}
-        initialEnd={formatDate(new Date())}
+        initialStart={formatDate(new Date("2022-02-15T04:00"))}
+        initialEnd={formatDate(new Date("2022-02-15T05:00"))}
         initialTitle=""
         initialDescription="A time to remember and appreciate classic art and more"
         initialAllDay={false}
@@ -150,16 +122,8 @@ describe("EventForm", () => {
   it("hides time sections when all day is selected", () => {
     render(
       <EventForm
-        initialStartDate={formatDate(new Date())}
-        initialEndDate={formatDate(new Date())}
-        initialStartTime={`${padNumberWith0Zero(
-          currentHour,
-        )}:${padNumberWith0Zero(currentMinute)}`}
-        initialEndTime={`${padNumberWith0Zero(
-          currentHour + 1,
-        )}:${padNumberWith0Zero(currentMinute)}`}
-        initialStart={formatDate(new Date())}
-        initialEnd={formatDate(new Date())}
+        initialStart={formatDate(new Date("2022-02-15T04:00"))}
+        initialEnd={formatDate(new Date("2022-02-15T05:00"))}
         initialTitle="Arty party"
         initialDescription="A time to remember and appreciate classic art and more"
         initialAllDay={true}
@@ -184,16 +148,8 @@ describe("EventForm", () => {
       const onFormSubmitMock = jest.fn();
       render(
         <EventForm
-          initialStartDate={formatDate(new Date())}
-          initialEndDate={formatDate(new Date())}
-          initialStartTime={`${padNumberWith0Zero(
-            currentHour,
-          )}:${padNumberWith0Zero(currentMinute)}`}
-          initialEndTime={`${padNumberWith0Zero(
-            currentHour + 1,
-          )}:${padNumberWith0Zero(currentMinute)}`}
-          initialStart={formatDate(new Date())}
-          initialEnd={formatDate(new Date())}
+          initialStart={formatDate(new Date("2022-02-15T04:00"))}
+          initialEnd={formatDate(new Date("2022-02-15T05:00"))}
           initialTitle="Arty party"
           initialDescription="A time to remember and appreciate classic art and more"
           initialAllDay={false}
@@ -227,14 +183,8 @@ describe("EventForm", () => {
       )}:${padNumberWith0Zero(currentMinute)}`;
       render(
         <EventForm
-          initialStartDate={startDate}
-          initialEndDate={startDate}
-          initialStartTime={startTime}
-          initialEndTime={`${padNumberWith0Zero(
-            currentHour + 1,
-          )}:${padNumberWith0Zero(currentMinute)}`}
-          initialStart={formatDate(new Date())}
-          initialEnd={formatDate(new Date())}
+          initialStart={formatDate(new Date("2022-02-15T04:00"))}
+          initialEnd={formatDate(new Date("2022-02-15T05:00"))}
           initialTitle="Mary's Chicken Feast"
           initialDescription="A time to remember and appreciate chicken nuggets and more"
           initialAllDay={false}
@@ -258,14 +208,8 @@ describe("EventForm", () => {
       )}:${padNumberWith0Zero(currentMinute)}`;
       render(
         <EventForm
-          initialStartDate={startDate}
-          initialEndDate={startDate}
-          initialStartTime={startTime}
-          initialEndTime={`${padNumberWith0Zero(
-            currentHour + 1,
-          )}:${padNumberWith0Zero(currentMinute)}`}
-          initialStart={formatDate(new Date())}
-          initialEnd={formatDate(new Date())}
+          initialStart={formatDate(new Date("2022-02-15T04:00"))}
+          initialEnd={formatDate(new Date("2022-02-15T05:00"))}
           initialTitle="Mary's Chicken Feast"
           initialDescription="A time to remember and appreciate chicken nuggets and more"
           initialAllDay={false}

--- a/ui/src/EventForm.test.tsx
+++ b/ui/src/EventForm.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import React from "react";
 
 import userEvent from "@testing-library/user-event";
-import { formatDate, getDateTimeString, padNumberWith0Zero } from "./lib";
+import { getDateTimeString } from "./lib";
 import EventForm from "./EventForm";
 
 describe("EventForm", () => {
@@ -21,19 +21,15 @@ describe("EventForm", () => {
   });
 
   it("displays initial values", () => {
-    const datePlusHours: Function = (date: Date, hours: number): Date => {
-      date.setHours(date.getHours() + hours);
-      return date;
-    };
     render(
       <EventForm
-        initialStart={formatDate(new Date())}
-        initialEnd={formatDate(datePlusHours(new Date(), 1))}
+        initialStart={new Date("2022-02-15T04:00").toISOString()}
+        initialEnd={new Date("2022-02-15T05:00").toISOString()}
         initialTitle="Mary's Chicken Feast"
         initialDescription="A time to remember and appreciate chicken nuggets and more"
         initialAllDay={false}
         initialRecurring={true}
-        initialRecurrenceEnd={formatDate(new Date("2022-06-15T04:00"))}
+        initialRecurrenceEnd={new Date("2022-06-15T04:00").toISOString()}
         onFormSubmit={() => {}}
         isCreate={true}
       />,
@@ -56,13 +52,13 @@ describe("EventForm", () => {
   it("displays `Save` button when `isCreate` is false", () => {
     render(
       <EventForm
-        initialStart={formatDate(new Date("2022-02-15T04:00"))}
-        initialEnd={formatDate(new Date("2022-02-15T05:00"))}
+        initialStart={new Date("2022-02-15T04:00").toISOString()}
+        initialEnd={new Date("2022-02-15T05:00").toISOString()}
         initialTitle="Arty party"
         initialDescription="A time to remember and appreciate classic art and more"
         initialAllDay={false}
         initialRecurring={false}
-        initialRecurrenceEnd={formatDate(new Date("2022-06-15T04:00"))}
+        initialRecurrenceEnd={new Date("2022-06-15T04:00").toISOString()}
         onFormSubmit={() => {}}
         isCreate={false}
       />,
@@ -75,13 +71,13 @@ describe("EventForm", () => {
     const onFormSubmitMock = jest.fn();
     render(
       <EventForm
-        initialStart={formatDate(new Date("2022-02-15T04:00"))}
-        initialEnd={formatDate(new Date("2022-02-15T05:00"))}
+        initialStart={new Date("2022-02-15T04:00").toISOString()}
+        initialEnd={new Date("2022-02-15T05:00").toISOString()}
         initialTitle="Arty party"
         initialDescription="A time to remember and appreciate classic art and more"
         initialAllDay={false}
         initialRecurring={false}
-        initialRecurrenceEnd={formatDate(new Date("2022-06-15T04:00"))}
+        initialRecurrenceEnd={new Date("2022-06-15T04:00").toISOString()}
         onFormSubmit={onFormSubmitMock}
         isCreate={false}
       />,
@@ -104,13 +100,13 @@ describe("EventForm", () => {
     const onFormSubmitMock = jest.fn();
     render(
       <EventForm
-        initialStart={formatDate(new Date("2022-02-15T04:00"))}
-        initialEnd={formatDate(new Date("2022-02-15T05:00"))}
+        initialStart={new Date("2022-02-15T04:00").toISOString()}
+        initialEnd={new Date("2022-02-15T05:00").toISOString()}
         initialTitle=""
         initialDescription="A time to remember and appreciate classic art and more"
         initialAllDay={false}
         initialRecurring={false}
-        initialRecurrenceEnd={formatDate(new Date("2022-06-15T04:00"))}
+        initialRecurrenceEnd={new Date("2022-06-15T04:00").toISOString()}
         onFormSubmit={onFormSubmitMock}
         isCreate={false}
       />,
@@ -122,13 +118,13 @@ describe("EventForm", () => {
   it("hides time sections when all day is selected", () => {
     render(
       <EventForm
-        initialStart={formatDate(new Date("2022-02-15T04:00"))}
-        initialEnd={formatDate(new Date("2022-02-15T05:00"))}
+        initialStart={new Date("2022-02-15T04:00").toISOString()}
+        initialEnd={new Date("2022-02-15T05:00").toISOString()}
         initialTitle="Arty party"
         initialDescription="A time to remember and appreciate classic art and more"
         initialAllDay={true}
         initialRecurring={false}
-        initialRecurrenceEnd={formatDate(new Date("2022-06-15T04:00"))}
+        initialRecurrenceEnd={new Date("2022-06-15T04:00").toISOString()}
         onFormSubmit={() => {}}
         isCreate={false}
       />,
@@ -148,13 +144,13 @@ describe("EventForm", () => {
       const onFormSubmitMock = jest.fn();
       render(
         <EventForm
-          initialStart={formatDate(new Date("2022-02-15T04:00"))}
-          initialEnd={formatDate(new Date("2022-02-15T05:00"))}
+          initialStart={new Date("2022-02-15T04:00").toISOString()}
+          initialEnd={new Date("2022-02-15T05:00").toISOString()}
           initialTitle="Arty party"
           initialDescription="A time to remember and appreciate classic art and more"
           initialAllDay={false}
           initialRecurring={true}
-          initialRecurrenceEnd={formatDate(new Date("2023-02-15T04:00"))}
+          initialRecurrenceEnd={new Date("2023-02-15T04:00").toISOString()}
           onFormSubmit={onFormSubmitMock}
           isCreate={false}
         />,
@@ -177,19 +173,15 @@ describe("EventForm", () => {
     });
 
     it("displays recurring defaults when recurring is selected", () => {
-      const startDate = formatDate(new Date());
-      const startTime = `${padNumberWith0Zero(
-        currentHour,
-      )}:${padNumberWith0Zero(currentMinute)}`;
       render(
         <EventForm
-          initialStart={formatDate(new Date("2022-02-15T04:00"))}
-          initialEnd={formatDate(new Date("2022-02-15T05:00"))}
+          initialStart={new Date("2022-02-15T04:00").toISOString()}
+          initialEnd={new Date("2022-02-15T05:00").toISOString()}
           initialTitle="Mary's Chicken Feast"
           initialDescription="A time to remember and appreciate chicken nuggets and more"
           initialAllDay={false}
           initialRecurring={true}
-          initialRecurrenceEnd={formatDate(new Date("2023-02-15T04:00"))}
+          initialRecurrenceEnd={new Date("2023-02-15T04:00").toISOString()}
           onFormSubmit={() => {}}
           isCreate={true}
         />,
@@ -202,19 +194,15 @@ describe("EventForm", () => {
     });
 
     it("allows user to choose between monthly and weekly recurrence", () => {
-      const startDate = formatDate(new Date());
-      const startTime = `${padNumberWith0Zero(
-        currentHour,
-      )}:${padNumberWith0Zero(currentMinute)}`;
       render(
         <EventForm
-          initialStart={formatDate(new Date("2022-02-15T04:00"))}
-          initialEnd={formatDate(new Date("2022-02-15T05:00"))}
+          initialStart={new Date("2022-02-15T04:00").toISOString()}
+          initialEnd={new Date("2022-02-15T05:00").toISOString()}
           initialTitle="Mary's Chicken Feast"
           initialDescription="A time to remember and appreciate chicken nuggets and more"
           initialAllDay={false}
           initialRecurring={true}
-          initialRecurrenceEnd={formatDate(new Date("2023-02-15T04:00"))}
+          initialRecurrenceEnd={new Date("2023-02-15T04:00").toISOString()}
           onFormSubmit={() => {}}
           isCreate={true}
         />,

--- a/ui/src/EventForm.tsx
+++ b/ui/src/EventForm.tsx
@@ -1,15 +1,17 @@
 import React, { useState } from "react";
-import { formatDate, getDateTimeString, padNumberWith0Zero } from "./lib";
+import {
+  formatDate,
+  formatTime,
+  getDateTimeString,
+  applyTimeToDate,
+  padNumberWith0Zero,
+} from "./lib";
 import { Checkbox, RadioGroup, Radio, Stack } from "@chakra-ui/react";
 import s from "./EventForm.module.css";
 
 interface FormProps {
-  initialStartDate: string;
-  initialEndDate: string;
-  initialStartTime: string;
-  initialEndTime: string;
-  initialStart: string;
-  initialEnd: string;
+  initialStart: string; //"2022-02-15T04:00"
+  initialEnd: string; //"2022-02-15T04:00"
   initialTitle: string;
   initialDescription: string;
   initialAllDay: boolean;
@@ -20,10 +22,6 @@ interface FormProps {
 }
 
 const EventForm = ({
-  initialStartDate,
-  initialEndDate,
-  initialStartTime,
-  initialEndTime,
   initialStart,
   initialEnd,
   initialTitle = "",
@@ -34,13 +32,31 @@ const EventForm = ({
   onFormSubmit,
   isCreate,
 }: FormProps) => {
-  const [startDate, setStartDate] = useState<string>(initialStartDate);
-  const [endDate, setEndDate] = useState<string>(initialEndDate);
-  const [startTime, setStartTime] = useState<string>(initialStartTime);
-  const [endTime, setEndTime] = useState<string>(initialEndTime);
-
-  const [start, setStart] = useState<string>(initialStart);
-  const [end, setEnd] = useState<string>(initialEnd);
+  const getYearMonthDay = (date: Date) => {
+    const month =
+      (date.getMonth() + 1).toString().length < 2
+        ? `0${date.getMonth() + 1}`
+        : date.getMonth() + 1;
+    const day =
+      date.getDate().toString().length < 2
+        ? `0${date.getDate()}`
+        : date.getDate();
+    return `${date.getFullYear()}-${month}-${day}`;
+  };
+  console.log("initial start", initialStart);
+  const [startDate, setStartDate] = useState<string>(
+    getYearMonthDay(new Date(initialStart)),
+  );
+  console.log("startDate", startDate);
+  const [endDate, setEndDate] = useState<string>(
+    getYearMonthDay(new Date(initialEnd)),
+  );
+  const [startTime, setStartTime] = useState<string>(
+    new Date(initialStart).toLocaleTimeString("it-IT"),
+  );
+  const [endTime, setEndTime] = useState<string>(
+    new Date(initialEnd).toLocaleTimeString("it-IT"),
+  );
 
   const [error, setError] = useState<string | null>(null);
   const [title, setTitle] = useState<string>(initialTitle);
@@ -57,15 +73,16 @@ const EventForm = ({
   )}:00`;
   const DEFAULT_END_TIME: string = `${padNumberWith0Zero(currentHour + 2)}:00`;
 
-  const recurrenceBeginDate = new Date(getDateTimeString(startDate, startTime));
+  const recurrenceBeginDate = new Date(applyTimeToDate(startDate, startTime));
 
-  const [recurrenceEndDate, setRecurrenceEndDate] =
-    useState<string>(initialRecurrenceEnd);
+  const [recurrenceEndDate, setRecurrenceEndDate] = useState<string>(
+    getYearMonthDay(new Date(initialRecurrenceEnd)),
+  );
 
   const handleFormSubmit = async (_: React.MouseEvent<HTMLButtonElement>) => {
-    const startDateAndTime: string = getDateTimeString(startDate, startTime);
-    const endDateAndTime: string = getDateTimeString(endDate, endTime);
-    const recurrenceEndDateAndTime: string = getDateTimeString(
+    const startDateAndTime: string = applyTimeToDate(startDate, startTime);
+    const endDateAndTime: string = applyTimeToDate(endDate, endTime);
+    const recurrenceEndDateAndTime: string = applyTimeToDate(
       recurrenceEndDate,
       startTime,
     );
@@ -144,6 +161,7 @@ const EventForm = ({
           min={formatDate(new Date())}
           type="date"
           onChange={(e) => {
+            console.log("e.target.value", e.target.value);
             setStartDate(e.target.value);
             setEndDate(e.target.value);
           }}

--- a/ui/src/EventForm.tsx
+++ b/ui/src/EventForm.tsx
@@ -1,11 +1,5 @@
 import React, { useState } from "react";
-import {
-  formatDate,
-  formatTime,
-  getDateTimeString,
-  applyTimeToDate,
-  padNumberWith0Zero,
-} from "./lib";
+import { formatDate, applyTimeToDate, padNumberWith0Zero } from "./lib";
 import { Checkbox, RadioGroup, Radio, Stack } from "@chakra-ui/react";
 import s from "./EventForm.module.css";
 
@@ -43,11 +37,9 @@ const EventForm = ({
         : date.getDate();
     return `${date.getFullYear()}-${month}-${day}`;
   };
-  console.log("initial start", initialStart);
   const [startDate, setStartDate] = useState<string>(
     getYearMonthDay(new Date(initialStart)),
   );
-  console.log("startDate", startDate);
   const [endDate, setEndDate] = useState<string>(
     getYearMonthDay(new Date(initialEnd)),
   );

--- a/ui/src/EventForm.tsx
+++ b/ui/src/EventForm.tsx
@@ -22,7 +22,7 @@ const EventForm = ({
   initialEndDate,
   initialStartTime,
   initialEndTime,
-  initialTitle,
+  initialTitle = "",
   initialDescription = "",
   initialAllDay,
   initialRecurring,
@@ -36,8 +36,6 @@ const EventForm = ({
   const [endTime, setEndTime] = useState<string>(initialEndTime);
   const [error, setError] = useState<string | null>(null);
   const [title, setTitle] = useState<string>(initialTitle);
-  // `|| ""` prevents warning in tests
-  // "Warning: A component is changing an uncontrolled input of type text to be controlled."
   const [description, setDescription] = useState<string>(initialDescription);
   const [allDay, setAllDay] = useState<boolean>(initialAllDay);
   const [recurring, setRecurring] = useState<boolean>(initialRecurring);

--- a/ui/src/EventForm.tsx
+++ b/ui/src/EventForm.tsx
@@ -1,5 +1,10 @@
 import React, { useState } from "react";
-import { formatDate, applyTimeToDate, padNumberWith0Zero } from "./lib";
+import {
+  formatDate,
+  getDateTimeString,
+  padNumberWith0Zero,
+  timeFormat,
+} from "./lib";
 import { Checkbox, RadioGroup, Radio, Stack } from "@chakra-ui/react";
 import s from "./EventForm.module.css";
 
@@ -33,10 +38,11 @@ const EventForm = ({
     formatDate(new Date(initialEnd)),
   );
   const [startTime, setStartTime] = useState<string>(
-    new Date(initialStart).toLocaleTimeString("it-IT"),
+    timeFormat(new Date(initialStart)),
   );
+
   const [endTime, setEndTime] = useState<string>(
-    new Date(initialEnd).toLocaleTimeString("it-IT"),
+    timeFormat(new Date(initialEnd)),
   );
 
   const [error, setError] = useState<string | null>(null);
@@ -54,16 +60,16 @@ const EventForm = ({
   )}:00`;
   const DEFAULT_END_TIME: string = `${padNumberWith0Zero(currentHour + 2)}:00`;
 
-  const recurrenceBeginDate = new Date(applyTimeToDate(startDate, startTime));
+  const recurrenceBeginDate = new Date(getDateTimeString(startDate, startTime));
 
   const [recurrenceEndDate, setRecurrenceEndDate] = useState<string>(
     formatDate(new Date(initialRecurrenceEnd)),
   );
 
   const handleFormSubmit = async (_: React.MouseEvent<HTMLButtonElement>) => {
-    const startDateAndTime: string = applyTimeToDate(startDate, startTime);
-    const endDateAndTime: string = applyTimeToDate(endDate, endTime);
-    const recurrenceEndDateAndTime: string = applyTimeToDate(
+    const startDateAndTime: string = getDateTimeString(startDate, startTime);
+    const endDateAndTime: string = getDateTimeString(endDate, endTime);
+    const recurrenceEndDateAndTime: string = getDateTimeString(
       recurrenceEndDate,
       startTime,
     );

--- a/ui/src/EventForm.tsx
+++ b/ui/src/EventForm.tsx
@@ -9,13 +9,13 @@ import { Checkbox, RadioGroup, Radio, Stack } from "@chakra-ui/react";
 import s from "./EventForm.module.css";
 
 interface FormProps {
-  initialStart: string; //"2022-02-15T04:00"
-  initialEnd: string; //"2022-02-15T04:00"
+  initialStart: string; // ex. "2023-01-25T08:00:00.000Z"
+  initialEnd: string; // ex. "2023-01-25T09:00:00.000Z"
   initialTitle: string;
   initialDescription: string;
   initialAllDay: boolean;
   initialRecurring: boolean;
-  initialRecurrenceEnd: string;
+  initialRecurrenceEnd: string; // ex. "2023-01-25T08:00:00.000Z"
   onFormSubmit: Function;
   isCreate: boolean;
 }
@@ -31,6 +31,7 @@ const EventForm = ({
   onFormSubmit,
   isCreate,
 }: FormProps) => {
+  console.log(initialStart, initialEnd, initialRecurrenceEnd);
   const [startDate, setStartDate] = useState<string>(
     formatDate(new Date(initialStart)),
   );

--- a/ui/src/EventForm.tsx
+++ b/ui/src/EventForm.tsx
@@ -8,6 +8,8 @@ interface FormProps {
   initialEndDate: string;
   initialStartTime: string;
   initialEndTime: string;
+  initialStart: string;
+  initialEnd: string;
   initialTitle: string;
   initialDescription: string;
   initialAllDay: boolean;
@@ -22,6 +24,8 @@ const EventForm = ({
   initialEndDate,
   initialStartTime,
   initialEndTime,
+  initialStart,
+  initialEnd,
   initialTitle = "",
   initialDescription = "",
   initialAllDay,
@@ -34,6 +38,10 @@ const EventForm = ({
   const [endDate, setEndDate] = useState<string>(initialEndDate);
   const [startTime, setStartTime] = useState<string>(initialStartTime);
   const [endTime, setEndTime] = useState<string>(initialEndTime);
+
+  const [start, setStart] = useState<string>(initialStart);
+  const [end, setEnd] = useState<string>(initialEnd);
+
   const [error, setError] = useState<string | null>(null);
   const [title, setTitle] = useState<string>(initialTitle);
   const [description, setDescription] = useState<string>(initialDescription);

--- a/ui/src/EventForm.tsx
+++ b/ui/src/EventForm.tsx
@@ -31,7 +31,6 @@ const EventForm = ({
   onFormSubmit,
   isCreate,
 }: FormProps) => {
-  console.log(initialStart, initialEnd, initialRecurrenceEnd);
   const [startDate, setStartDate] = useState<string>(
     formatDate(new Date(initialStart)),
   );

--- a/ui/src/EventForm.tsx
+++ b/ui/src/EventForm.tsx
@@ -26,22 +26,11 @@ const EventForm = ({
   onFormSubmit,
   isCreate,
 }: FormProps) => {
-  const getYearMonthDay = (date: Date) => {
-    const month =
-      (date.getMonth() + 1).toString().length < 2
-        ? `0${date.getMonth() + 1}`
-        : date.getMonth() + 1;
-    const day =
-      date.getDate().toString().length < 2
-        ? `0${date.getDate()}`
-        : date.getDate();
-    return `${date.getFullYear()}-${month}-${day}`;
-  };
   const [startDate, setStartDate] = useState<string>(
-    getYearMonthDay(new Date(initialStart)),
+    formatDate(new Date(initialStart)),
   );
   const [endDate, setEndDate] = useState<string>(
-    getYearMonthDay(new Date(initialEnd)),
+    formatDate(new Date(initialEnd)),
   );
   const [startTime, setStartTime] = useState<string>(
     new Date(initialStart).toLocaleTimeString("it-IT"),
@@ -68,7 +57,7 @@ const EventForm = ({
   const recurrenceBeginDate = new Date(applyTimeToDate(startDate, startTime));
 
   const [recurrenceEndDate, setRecurrenceEndDate] = useState<string>(
-    getYearMonthDay(new Date(initialRecurrenceEnd)),
+    formatDate(new Date(initialRecurrenceEnd)),
   );
 
   const handleFormSubmit = async (_: React.MouseEvent<HTMLButtonElement>) => {
@@ -153,7 +142,6 @@ const EventForm = ({
           min={formatDate(new Date())}
           type="date"
           onChange={(e) => {
-            console.log("e.target.value", e.target.value);
             setStartDate(e.target.value);
             setEndDate(e.target.value);
           }}

--- a/ui/src/lib.test.ts
+++ b/ui/src/lib.test.ts
@@ -4,6 +4,7 @@ import {
   oneYearLater,
   singleModalDateFormat,
   dateFormatWithYear,
+  datePlusHours,
 } from "./lib";
 
 describe("lib functions", () => {
@@ -85,8 +86,21 @@ describe("lib functions", () => {
       const date = new Date("2022-02-15T04:00");
 
       expect(oneYearLater(date.toUTCString())).toEqual(
-        new Date("2023-02-15T04:00")
+        new Date("2023-02-15T04:00"),
       );
+    });
+  });
+
+  describe("datePlusHours", () => {
+    it("returns a date plus `x` hours, where `x` is positive", () => {
+      const date = new Date("2022-02-15T04:00");
+
+      expect(datePlusHours(date, 1)).toEqual(new Date("2022-02-15T05:00"));
+    });
+    it("returns a date plus `x` hours, where `x` is negative", () => {
+      const date = new Date("2022-02-15T04:00");
+
+      expect(datePlusHours(date, -2)).toEqual(new Date("2022-02-15T02:00"));
     });
   });
 });

--- a/ui/src/lib.ts
+++ b/ui/src/lib.ts
@@ -4,6 +4,7 @@ import { EventInputTransformer, EventInput } from "@fullcalendar/react";
 const padNumberWith0Zero: Function = (num: Number): string =>
   num.toString().padStart(2, "0");
 
+// ex. 2022-01-15
 const formatDate: Function = (date: Date): string => {
   return [
     date.getFullYear(),
@@ -33,12 +34,14 @@ const dateFormatWithYear = (date: Date) => {
   })} ${date.getDate()} ${date.getFullYear()}`;
 };
 
+// ex. 13:00
 const timeFormat = (date: Date) =>
   `${date.toLocaleTimeString("it-IT", {
     hour: "2-digit",
     minute: "2-digit",
   })}`;
 
+// ex. 01:00 PM
 const timeFormatAmPm = (date: Date) =>
   `${date.toLocaleTimeString("en-US", {
     hour: "2-digit",
@@ -83,14 +86,6 @@ const singleModalDateFormat: Function = (dateTimeUtc: string) => {
 
 const getDateTimeString = (date: string, time: string) => `${date}T${time}`;
 
-const applyTimeToDate = (date: string, time: string) => {
-  const dateTime = new Date(date);
-  const [hours, mins, _] = time.split(":");
-  dateTime.setHours(parseInt(hours));
-  dateTime.setMinutes(parseInt(mins));
-  return dateTime.toISOString();
-};
-
 const oneYearLater = (utcString: string) => {
   const newDate = new Date(utcString);
 
@@ -116,5 +111,4 @@ export {
   oneYearLater,
   singleModalDateFormat,
   dateFormatWithYear,
-  applyTimeToDate,
 };

--- a/ui/src/lib.ts
+++ b/ui/src/lib.ts
@@ -4,6 +4,7 @@ import { EventInputTransformer, EventInput } from "@fullcalendar/react";
 const padNumberWith0Zero: Function = (num: Number): string =>
   num.toString().padStart(2, "0");
 
+// Returns a string of the format yyyy-mm-dd
 // ex. 2022-01-15
 const formatDate: Function = (date: Date): string => {
   return [
@@ -14,7 +15,6 @@ const formatDate: Function = (date: Date): string => {
 };
 
 const dateMinusOneDay: Function = (date: Date): Date => {
-  // subtract a day from the given date
   date.setDate(date.getDate() - 1);
   return date;
 };
@@ -34,15 +34,17 @@ const dateFormatWithYear = (date: Date) => {
   })} ${date.getDate()} ${date.getFullYear()}`;
 };
 
+// Returns a string in the miltary format hh:mm
 // ex. 13:00
-const timeFormat = (date: Date) =>
+const timeFormat = (date: Date): string =>
   `${date.toLocaleTimeString("it-IT", {
     hour: "2-digit",
     minute: "2-digit",
   })}`;
 
+// Returns a string in the format hh:mm (AM/PM)
 // ex. 01:00 PM
-const timeFormatAmPm = (date: Date) =>
+const timeFormatAmPm = (date: Date): string =>
   `${date.toLocaleTimeString("en-US", {
     hour: "2-digit",
     minute: "2-digit",

--- a/ui/src/lib.ts
+++ b/ui/src/lib.ts
@@ -18,23 +18,29 @@ const dateMinusOneDay: Function = (date: Date): Date => {
   return date;
 };
 
-const dateFormat = (selectedEventDate: Date) =>
-  `${selectedEventDate.toLocaleString("default", {
+const dateFormat = (date: Date) =>
+  `${date.toLocaleString("default", {
     weekday: "short",
-  })}, ${selectedEventDate.toLocaleString("default", {
+  })}, ${date.toLocaleString("default", {
     month: "short",
-  })} ${selectedEventDate.getDate()}`;
+  })} ${date.getDate()}`;
 
-const dateFormatWithYear = (selectedEventDate: Date) => {
-  return `${selectedEventDate.toLocaleString("default", {
+const dateFormatWithYear = (date: Date) => {
+  return `${date.toLocaleString("default", {
     weekday: "short",
-  })}, ${selectedEventDate.toLocaleString("default", {
+  })}, ${date.toLocaleString("default", {
     month: "short",
-  })} ${selectedEventDate.getDate()} ${selectedEventDate.getFullYear()}`;
+  })} ${date.getDate()} ${date.getFullYear()}`;
 };
 
-const timeFormat = (selectedEventDate: Date) =>
-  `${selectedEventDate.toLocaleTimeString("default", {
+const timeFormat = (date: Date) =>
+  `${date.toLocaleTimeString("it-IT", {
+    hour: "2-digit",
+    minute: "2-digit",
+  })}`;
+
+const timeFormatAmPm = (date: Date) =>
+  `${date.toLocaleTimeString("en-US", {
     hour: "2-digit",
     minute: "2-digit",
   })}`;
@@ -58,20 +64,20 @@ const modalDateFormat: Function = ({
   if (startDate === endDate && allDay) {
     return `${startDate}`;
   } else if (startDate === endDate) {
-    return `${startDate} · ${timeFormat(start)} - ${timeFormat(end)}`;
+    return `${startDate} · ${timeFormatAmPm(start)} - ${timeFormatAmPm(end)}`;
   } else if (allDay) {
     return `${startDate} - ${endDate}`;
   } else {
-    return `${startDate}, ${timeFormat(start)} - ${endDate}, ${timeFormat(
-      end,
-    )}`;
+    return `${startDate}, ${timeFormatAmPm(
+      start,
+    )} - ${endDate}, ${timeFormatAmPm(end)}`;
   }
 };
 
 const singleModalDateFormat: Function = (dateTimeUtc: string) => {
   const date = new Date(dateTimeUtc);
   const formattedDate = dateFormatWithYear(date);
-  const formattedTime = timeFormat(date);
+  const formattedTime = timeFormatAmPm(date);
   return `${formattedDate}, ${formattedTime}`;
 };
 

--- a/ui/src/lib.ts
+++ b/ui/src/lib.ts
@@ -34,6 +34,11 @@ const dateFormatWithYear = (date: Date) => {
   })} ${date.getDate()} ${date.getFullYear()}`;
 };
 
+const datePlusHours: Function = (date: Date, hours: number): Date => {
+  date.setHours(date.getHours() + hours);
+  return date;
+};
+
 // Returns a string in the miltary format hh:mm
 // ex. 13:00
 const timeFormat = (date: Date): string =>
@@ -103,14 +108,15 @@ const addDayToAllDayEvent: EventInputTransformer = (event: EventInput) => {
 
 export {
   addDayToAllDayEvent,
+  dateFormat,
+  dateFormatWithYear,
   dateMinusOneDay,
+  datePlusHours,
   formatDate,
   getDateTimeString,
-  padNumberWith0Zero,
   modalDateFormat,
-  dateFormat,
-  timeFormat,
   oneYearLater,
+  padNumberWith0Zero,
   singleModalDateFormat,
-  dateFormatWithYear,
+  timeFormat,
 };

--- a/ui/src/lib.ts
+++ b/ui/src/lib.ts
@@ -12,16 +12,6 @@ const formatDate: Function = (date: Date): string => {
   ].join("-");
 };
 
-const formatDateMinusOneDay: Function = (date: Date): string => {
-  // subtract a day from the given date
-  date.setDate(date.getDate() - 1);
-  return [
-    date.getFullYear(),
-    padNumberWith0Zero(date.getMonth() + 1),
-    padNumberWith0Zero(date.getDate()),
-  ].join("-");
-};
-
 const dateMinusOneDay: Function = (date: Date): Date => {
   // subtract a day from the given date
   date.setDate(date.getDate() - 1);
@@ -94,11 +84,6 @@ const applyTimeToDate = (date: string, time: string) => {
   return dateTime.toISOString();
 };
 
-const formatTime = (utcString: string) =>
-  `${padNumberWith0Zero(new Date(utcString).getHours())}:${padNumberWith0Zero(
-    new Date(utcString).getMinutes(),
-  )}`;
-
 const oneYearLater = (utcString: string) => {
   const newDate = new Date(utcString);
 
@@ -116,11 +101,9 @@ export {
   addDayToAllDayEvent,
   dateMinusOneDay,
   formatDate,
-  formatDateMinusOneDay,
   getDateTimeString,
   padNumberWith0Zero,
   modalDateFormat,
-  formatTime,
   dateFormat,
   timeFormat,
   oneYearLater,

--- a/ui/src/lib.ts
+++ b/ui/src/lib.ts
@@ -80,7 +80,8 @@ const getDateTimeString = (date: string, time: string) => `${date}T${time}`;
 const applyTimeToDate = (date: string, time: string) => {
   const dateTime = new Date(date);
   const [hours, mins, _] = time.split(":");
-  dateTime.setHours(parseInt(hours), parseInt(mins));
+  dateTime.setHours(parseInt(hours));
+  dateTime.setMinutes(parseInt(mins));
   return dateTime.toISOString();
 };
 

--- a/ui/src/lib.ts
+++ b/ui/src/lib.ts
@@ -22,6 +22,12 @@ const formatDateMinusOneDay: Function = (date: Date): string => {
   ].join("-");
 };
 
+const dateMinusOneDay: Function = (date: Date): Date => {
+  // subtract a day from the given date
+  date.setDate(date.getDate() - 1);
+  return date;
+};
+
 const dateFormat = (selectedEventDate: Date) =>
   `${selectedEventDate.toLocaleString("default", {
     weekday: "short",
@@ -81,6 +87,13 @@ const singleModalDateFormat: Function = (dateTimeUtc: string) => {
 
 const getDateTimeString = (date: string, time: string) => `${date}T${time}`;
 
+const applyTimeToDate = (date: string, time: string) => {
+  const dateTime = new Date(date);
+  const [hours, mins, _] = time.split(":");
+  dateTime.setHours(parseInt(hours), parseInt(mins));
+  return dateTime.toISOString();
+};
+
 const formatTime = (utcString: string) =>
   `${padNumberWith0Zero(new Date(utcString).getHours())}:${padNumberWith0Zero(
     new Date(utcString).getMinutes(),
@@ -101,6 +114,7 @@ const addDayToAllDayEvent: EventInputTransformer = (event: EventInput) => {
 
 export {
   addDayToAllDayEvent,
+  dateMinusOneDay,
   formatDate,
   formatDateMinusOneDay,
   getDateTimeString,
@@ -112,4 +126,5 @@ export {
   oneYearLater,
   singleModalDateFormat,
   dateFormatWithYear,
+  applyTimeToDate,
 };


### PR DESCRIPTION
_Closes:_ <ticketLink>

## Summary of changes
This PR updates the EventForm component to take in two date/time-related parameters, rather than four. Date and time are no longer split into two separate fields for start and end. 

Adds helper functions and removes unused/repeated helper functions. 

## Dev notes
This was done to make fixing the [default time bug](https://github.com/insightorchards/calendar-ui/issues/113) possible in a clean way.

## Testing

- [x] Unit tests
![image](https://user-images.githubusercontent.com/31298051/211254030-4621dd43-2e40-44d0-a417-fbef98f27965.png)

![image](https://user-images.githubusercontent.com/31298051/211254068-56786dd7-e746-422a-8f3c-f170f2f96b44.png)

![image](https://user-images.githubusercontent.com/31298051/211254047-ef212d9d-7133-4164-b68e-045b91cd60ec.png)


#### Screenshot of UI (local testing in browser)
