### PR TITLE
Cal 118 build recurring events using pattern model

### DIFF
--- a/api/models/entryException.js
+++ b/api/models/entryException.js
@@ -1,9 +1,18 @@
 const mongoose = require("mongoose");
 
-const calendarEntrySchema = new mongoose.Schema(
+const entryExceptionSchema = new mongoose.Schema(
   {
-    eventId: {
-      type: String,
+    deleted: {
+      type: Boolean,
+      required: true,
+    },
+    modified: {
+      type: Boolean,
+      required: true,
+    },
+    entryId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "CalendarEntry",
       required: true,
     },
     creatorId: {
@@ -30,32 +39,16 @@ const calendarEntrySchema = new mongoose.Schema(
       type: Date,
       required: true,
     },
-    recurring: {
-      type: Boolean,
-      required: true,
-    },
-    recurrenceEndsUtc: {
-      type: Date,
-      required: false,
-    },
-    recurrencePattern: {
-      type: String,
-      required: false,
-    },
-    frequency: {
-      type: String,
-      required: false,
-    },
   },
   {
     timestamps: true,
   },
 );
 
-const CalendarEntry = mongoose.model(
-  "CalendarEntry",
-  calendarEntrySchema,
-  "calendarEntries",
+const EntryException = mongoose.model(
+  "EntryException",
+  entryExceptionSchema,
+  "entryExceptions",
 );
 
-module.exports = { CalendarEntry };
+module.exports = { EntryException };

--- a/docs/recurring-events-plan.md
+++ b/docs/recurring-events-plan.md
@@ -1,0 +1,71 @@
+### Recurring Events Plan
+
+We are using these two articles as our reference point:
+https://github.com/bmoeskau/Extensible/blob/master/recurrence-overview.md
+https://vertabelo.com/blog/again-and-again-managing-recurring-events-in-a-data-model/
+
+#### Schema
+
+CalendarEntry:
+eventId
+creatorId
+title
+description
+allDay
+startTimeUtc
+endTimeUtc
+recurrenceEndsUtc
+recurring
+recurrencePattern
+
+EntryException:
+id
+deleted: boolean
+modified: boolean
+entryId
+creatorId
+title
+description
+allDay
+startTimeUtc
+endTimeUtc
+
+#### Create
+
+Frontend will send input to backend: start, end, recurring, recurring end date
+Backend will calculate duration and use rrule to generate the rule string which will be stored
+Backend will send back 201 created
+
+#### Read of single event
+
+Frontend will request read of event using event ID and date
+Backend will generate event using rrule and date (range?)
+Backend will return generated event
+
+#### Read of all events
+
+Frontend will request all events for a range of time (i.e. one month)
+Backend will generate instances within that time range for every rule, (delete any deleted exceptions, and add in any updated exceptions) and include those events in the payload
+
+#### Update of single event
+
+Frontend will request update for single event
+Backend will generate rule exception with all of the event data and store in DB
+
+#### Update of all events
+
+Frontend will request update
+Backend will generate new rrule string using data and store on the event object
+Backend will return 201
+
+#### Delete of single event
+
+Frontend will request deletion of single event
+Backend will generate rule exception and mark it as deleted
+Backend will return 200
+
+#### Delete of all events
+
+Frontend will request deletion of series
+Backend will delete event and any exceptions
+Backend will return 200

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -88,7 +88,7 @@ describe("App", () => {
       await act(async () => {
         await render(<App />);
       });
-      expect(mockGetEntries).toHaveBeenCalledTimes(1);
+      expect(mockGetEntries).toHaveBeenCalledTimes(2);
       userEvent.click(screen.getByLabelText("add event"));
       userEvent.click(screen.getByLabelText("Title"));
       userEvent.type(
@@ -154,7 +154,7 @@ describe("App", () => {
       ]);
 
       render(<App />);
-      expect(mockGetEntries).toHaveBeenCalledTimes(1);
+      expect(mockGetEntries).toHaveBeenCalledTimes(2);
       const eventText = await screen.findByText("Dance");
       expect(eventText).toBeInTheDocument();
       eventText.click();
@@ -166,7 +166,7 @@ describe("App", () => {
     });
 
     it("deletes entry when delete button is clicked", async () => {
-      mockGetEntries.mockResolvedValueOnce([
+      mockGetEntries.mockResolvedValue([
         {
           _id: "123",
           end: "2022-02-27T05:43:37.868Z",
@@ -203,7 +203,7 @@ describe("App", () => {
       await act(async () => {
         await render(<App />);
       });
-      expect(mockGetEntries).toHaveBeenCalledTimes(1);
+      expect(mockGetEntries).toHaveBeenCalledTimes(2);
       const eventText = await screen.findByText("Dance");
       expect(eventText).toBeInTheDocument();
       await act(async () => {
@@ -348,7 +348,7 @@ describe("App", () => {
     });
 
     it("getEntry error displays error message", async () => {
-      mockGetEntries.mockResolvedValueOnce([
+      mockGetEntries.mockResolvedValue([
         {
           _id: "123",
           end: "2022-02-27T05:43:37.868Z",
@@ -369,7 +369,7 @@ describe("App", () => {
     });
 
     it("updateEntry displays an error message", async () => {
-      mockGetEntries.mockResolvedValueOnce([
+      mockGetEntries.mockResolvedValue([
         {
           _id: "123",
           end: "2022-02-27T05:43:37.868Z",
@@ -407,7 +407,7 @@ describe("App", () => {
     });
 
     it("deleteEntry displays an error message", async () => {
-      mockGetEntries.mockResolvedValueOnce([
+      mockGetEntries.mockResolvedValue([
         {
           _id: "123",
           end: "2022-02-27T05:43:37.868Z",
@@ -443,7 +443,7 @@ describe("App", () => {
 
       render(<App />);
 
-      expect(mockGetEntries).toHaveBeenCalledTimes(1);
+      expect(mockGetEntries).toHaveBeenCalledTimes(2);
       const eventText = await screen.findByText("Dance");
       expect(eventText).toBeInTheDocument();
       await act(async () => {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -92,6 +92,8 @@ const App = () => {
 
   const [modalAllDay, setModalAllDay] = useState<boolean>(false);
   const [apiError, setApiError] = useState<boolean>(false);
+  const [rangeStart, setRangeStart] = useState<string>("");
+  const [rangeEnd, setRangeEnd] = useState<string>("");
 
   const flashApiErrorMessage = () => {
     setApiError(true);
@@ -99,14 +101,14 @@ const App = () => {
   };
 
   useEffect(() => {
-    getEntries()
+    getEntries(rangeStart, rangeEnd)
       .then((entries) => {
         setEvents(entries);
       })
       .catch(() => {
         flashApiErrorMessage();
       });
-  }, []);
+  }, [rangeStart, rangeEnd]);
 
   const handleCreateEntry = async ({
     title,
@@ -141,7 +143,7 @@ const App = () => {
     }).catch(() => {
       flashApiErrorMessage();
     });
-    getEntries()
+    getEntries(rangeStart, rangeEnd)
       .then((entries) => {
         setEvents(entries);
         setShowOverlay(false);
@@ -174,7 +176,7 @@ const App = () => {
     e.preventDefault();
     deleteEntry(displayedEventData._id!)
       .then(() => {
-        getEntries().then((entries) => {
+        getEntries(rangeStart, rangeEnd).then((entries) => {
           setEvents(entries);
           setShowOverlay(false);
         });
@@ -227,7 +229,7 @@ const App = () => {
     })
       .then(() => {
         getEntryDetails(entryId);
-        getEntries().then((entries) => {
+        getEntries(rangeStart, rangeEnd).then((entries) => {
           setEvents(entries);
         });
       })
@@ -296,6 +298,10 @@ const App = () => {
                 }}
                 selectMirror={true}
                 height="100vh"
+                datesSet={(e) => {
+                  setRangeStart(new Date(e.startStr).toISOString());
+                  setRangeEnd(new Date(e.endStr).toISOString());
+                }}
                 eventDataTransform={addDayToAllDayEvent}
               />
             </div>

--- a/ui/src/client.test.ts
+++ b/ui/src/client.test.ts
@@ -28,7 +28,7 @@ describe("client functions", () => {
               recurring: true,
               startTimeUtc: "2024-06-06T01:07:00.000Z",
               endTimeUtc: "2024-06-06T05:07:00.000Z",
-              recurrenceEnd: "2024-06-06T05:07:00.000Z",
+              recurrenceEndsUtc: "2024-06-06T05:07:00.000Z",
               createdAt: "2022-12-05T05:27:52.212Z",
               updatedAt: "2022-12-05T05:27:52.212Z",
               __v: 0,
@@ -41,7 +41,9 @@ describe("client functions", () => {
         .spyOn(window, "fetch")
         .mockResolvedValue(mockResponse);
 
-      const result = await getEntries();
+      const start = "2023-01-01T08:00:00.000Z";
+      const end = "2023-02-12T08:00:00.000Z";
+      const result = await getEntries(start, end);
       expect(fetchSpy).toHaveBeenCalled();
       expect(result).toEqual([
         {
@@ -65,7 +67,10 @@ describe("client functions", () => {
       } as Response;
 
       jest.spyOn(window, "fetch").mockResolvedValue(mockResponse);
-      expect(() => getEntries()).rejects.toThrowError(
+
+      const start = "2023-01-01T08:00:00.000Z";
+      const end = "2023-02-12T08:00:00.000Z";
+      expect(() => getEntries(start, end)).rejects.toThrowError(
         new Error("Get entries request failed"),
       );
     });
@@ -194,7 +199,7 @@ describe("client functions", () => {
             allDay: false,
             recurring: true,
             recurrenceBegins: "2024-06-06T01:07:00.000Z",
-            recurrenceEndUtc: "2025-06-06T01:07:00.000Z",
+            recurrenceEndsUtc: "2025-06-06T01:07:00.000Z",
             startTimeUtc: "2024-06-06T01:07:00.000Z",
             endTimeUtc: "2024-06-06T05:07:00.000Z",
             createdAt: "2022-12-05T05:27:52.212Z",
@@ -229,7 +234,7 @@ describe("client functions", () => {
         allDay: false,
         recurring: true,
         recurrenceBegins: "2024-06-06T01:07:00.000Z",
-        recurrenceEndUtc: "2025-06-06T01:07:00.000Z",
+        recurrenceEndsUtc: "2025-06-06T01:07:00.000Z",
         startTimeUtc: "2024-06-06T01:07:00.000Z",
         endTimeUtc: "2024-06-06T05:07:00.000Z",
         createdAt: "2022-12-05T05:27:52.212Z",
@@ -328,7 +333,7 @@ describe("client functions", () => {
             allDay: false,
             recurring: true,
             recurrenceBegins: "2024-06-06T01:07:00.000Z",
-            recurrenceEndUtc: "2025-06-06T01:07:00.000Z",
+            recurrenceEndsUtc: "2025-06-06T01:07:00.000Z",
             startTimeUtc: "2024-06-06T01:07:00.000Z",
             endTimeUtc: "2024-06-06T05:07:00.000Z",
             createdAt: "2022-12-05T05:27:52.212Z",
@@ -363,7 +368,7 @@ describe("client functions", () => {
         allDay: false,
         recurring: true,
         recurrenceBegins: "2024-06-06T01:07:00.000Z",
-        recurrenceEndUtc: "2025-06-06T01:07:00.000Z",
+        recurrenceEndsUtc: "2025-06-06T01:07:00.000Z",
         startTimeUtc: "2024-06-06T01:07:00.000Z",
         endTimeUtc: "2024-06-06T05:07:00.000Z",
         createdAt: "2022-12-05T05:27:52.212Z",

--- a/ui/src/client.ts
+++ b/ui/src/client.ts
@@ -14,8 +14,8 @@ const notOk = (status: number) => {
   return !status.toString().match(/2\d+/);
 };
 
-const getEntries = async () => {
-  return fetch("http://localhost:4000/entries", {
+const getEntries = async (start: string, end: string) => {
+  return fetch(`http://localhost:4000/entries?start=${start}&end=${end}`, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",
@@ -36,7 +36,7 @@ const getEntries = async () => {
           end: event.endTimeUtc,
           allDay: event.allDay,
           recurring: event.recurring,
-          recurrenceEnd: event.recurrenceEnd,
+          recurrenceEnd: event.recurrenceEndsUtc,
         };
       });
       return result;
@@ -86,7 +86,7 @@ const createEntry = async ({
         recurring,
         frequency,
         recurrenceBegins: recurrenceBegins?.toISOString(),
-        recurrenceEnds: recurrenceEndUtc?.toISOString(),
+        recurrenceEndsUtc: recurrenceEndUtc?.toISOString(),
       }),
     });
   } else {


### PR DESCRIPTION
_Closes:_ #118

## Summary of changes
This PR builds out recurring events using the pattern model (where we store a recurrence pattern and then expand it into individual events on read). This approach is based on these two resources we found on recurring events:

https://github.com/bmoeskau/Extensible/blob/master/recurrence-overview.md
https://vertabelo.com/blog/again-and-again-managing-recurring-events-in-a-data-model/

This also updates the getEntries endpoint to take in a start and end so that we can search by date range for events. This ensures we only expand recurring events up to a month at a time.

Note: viewing a single recurring event is currently broken, but will be fixed in the next PR.

## Dev notes

## Testing

- [x] Unit tests

#### Screenshot of UI (local testing in browser)
