### PR TITLE
Cal 120 delete single instance of recurring event

### DIFF
--- a/api/app.test.js
+++ b/api/app.test.js
@@ -416,7 +416,7 @@ describe("DELETE / entry", () => {
     expect(updatedResponse.body.length).toEqual(10);
   });
 
-  it("cascades deletion to entry exceptions when recurring event is deleted", async () => {
+  it("cascades deletion to entry exceptions when recurring series is deleted", async () => {
     const date = new Date("04 January 2023 14:48 UTC");
     const oneYearLater = yearAfter(date);
 

--- a/api/app.test.js
+++ b/api/app.test.js
@@ -4,6 +4,7 @@ const supertest = require("supertest");
 const { app } = require("./app");
 const { dayAfter, yearAfter } = require("./lib/dateHelpers");
 const { RRule, RRuleSet, rrulestr } = require("rrule");
+const { EntryException } = require("./models/entryException");
 
 beforeAll(async () => {
   await connectDB();
@@ -342,7 +343,7 @@ describe("DELETE / entry", () => {
   const endTime = new Date("05 July 2011 14:48 UTC");
   const oneYearLater = yearAfter(startTime);
 
-  beforeEach(async () => {
+  it("deletes the selected entry from the database", async () => {
     data = await CalendarEntry.create({
       eventId: "123",
       creatorId: "456",
@@ -353,16 +354,79 @@ describe("DELETE / entry", () => {
       startTimeUtc: startTime,
       endTimeUtc: endTime,
     });
-  });
-
-  it("deletes the selected entry from the database", async () => {
     await supertest(app).delete(`/entries/${data._id}`).expect(200);
 
     const newCount = await CalendarEntry.countDocuments();
     expect(newCount).toEqual(0);
   });
 
+  it("deletes a single instance of a recurring event", async () => {
+    const date = new Date("04 January 2023 14:48 UTC");
+    const oneYearLater = yearAfter(date);
+
+    const createdEventData = await supertest(app)
+      .post("/entries")
+      .send({
+        eventId: "123",
+        creatorId: "456",
+        title: "Happy day",
+        description: "and a happy night too",
+        startTimeUtc: date,
+        endTimeUtc: dayAfter(date),
+        allDay: false,
+        recurring: true,
+        frequency: "monthly",
+        recurrenceEndsUtc: oneYearLater,
+      })
+      .expect(201);
+    const createdEvent = JSON.parse(createdEventData.text);
+
+    const rule = new RRule({
+      freq: RRule.MONTHLY,
+      dtstart: date,
+      until: oneYearLater,
+    });
+
+    const recurrences = rule.all();
+
+    const februaryFourth = recurrences[1];
+
+    const exceptionCount = await EntryException.countDocuments();
+    expect(exceptionCount).toEqual(0);
+
+    const response = await supertest(app)
+      .get(`/entries?start=${date}&end=${oneYearLater}`)
+      .expect(200);
+    expect(response.body.length).toEqual(11);
+
+    await supertest(app)
+      .delete(
+        `/entries/${
+          createdEvent._id
+        }?start=${februaryFourth.toISOString()}&applyToSeries=false`,
+      )
+      .expect(200);
+
+    const updatedExceptionCount = await EntryException.countDocuments();
+    expect(updatedExceptionCount).toEqual(1);
+
+    const updatedResponse = await supertest(app)
+      .get(`/entries?start=${date}&end=${oneYearLater}`)
+      .expect(200);
+    expect(updatedResponse.body.length).toEqual(10);
+  });
+
   it("catches and returns an error from CalendarEntry.deleteOne", async () => {
+    const data = await CalendarEntry.create({
+      eventId: "123",
+      creatorId: "456",
+      title: "Happy day",
+      description: "and a happy night too",
+      allDay: false,
+      recurring: false,
+      startTimeUtc: startTime,
+      endTimeUtc: endTime,
+    });
     const deleteMock = jest
       .spyOn(CalendarEntry, "deleteOne")
       .mockRejectedValue({ message: "error occurred" });

--- a/api/controllers/calendarEntry.controller.ts
+++ b/api/controllers/calendarEntry.controller.ts
@@ -260,7 +260,7 @@ export const deleteCalendarEntry = async (
         startTimeUtc: start,
       });
     } else {
-      await CalendarEntry.deleteOne({ _id: id });
+      entryToDelete.remove();
     }
     res.sendStatus(200);
   } catch (err) {

--- a/api/controllers/calendarEntry.controller.ts
+++ b/api/controllers/calendarEntry.controller.ts
@@ -227,7 +227,7 @@ export const getCalendarEntry = async (
       const startDate = new Date(start as string);
       const oneMinBefore = dateMinusMinutes(startDate, 1);
       const oneMinAfter = datePlusMinutes(startDate, 1);
-      const expandedEntry = expandRecurringEntry(
+      const expandedEntry = await expandRecurringEntry(
         entry,
         oneMinBefore,
         oneMinAfter,

--- a/api/models/calendarEntry.js
+++ b/api/models/calendarEntry.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+const { EntryException } = require("./entryException");
 
 const calendarEntrySchema = new mongoose.Schema(
   {
@@ -51,6 +52,11 @@ const calendarEntrySchema = new mongoose.Schema(
     timestamps: true,
   },
 );
+
+calendarEntrySchema.pre("remove", { document: true }, function (next) {
+  EntryException.remove({ entryId: this._id }).exec();
+  next();
+});
 
 const CalendarEntry = mongoose.model(
   "CalendarEntry",

--- a/api/models/entryException.js
+++ b/api/models/entryException.js
@@ -17,11 +17,11 @@ const entryExceptionSchema = new mongoose.Schema(
     },
     creatorId: {
       type: String,
-      required: true,
+      required: false,
     },
     title: {
       type: String,
-      required: true,
+      required: false,
     },
     description: {
       type: String,
@@ -29,7 +29,7 @@ const entryExceptionSchema = new mongoose.Schema(
     },
     allDay: {
       type: Boolean,
-      required: true,
+      required: false,
     },
     startTimeUtc: {
       type: Date,
@@ -37,7 +37,7 @@ const entryExceptionSchema = new mongoose.Schema(
     },
     endTimeUtc: {
       type: Date,
-      required: true,
+      required: false,
     },
   },
   {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -191,22 +191,6 @@ const App = () => {
     setEvents(expandedEvents);
   };
 
-  const setEventsWithExtraFields = (entries: any) => {
-    // We need to manually set the entryStart field
-    // so we can read it off the object later
-    // See https://fullcalendar.io/docs/event-parsing
-    // Can't use the 'start' field because it gets truncated
-    // for all day events when coming back from FullCalendar
-    const expandedEntries = entries.map((entry: any) => {
-      return {
-        ...entry,
-        entryStart: entry.start,
-      };
-    });
-
-    setEvents(expandedEntries);
-  };
-
   const handleDeleteSeries = () => {
     deleteEntry(displayedEventData._id!, displayedEventData.startTimeUtc, true)
       .then(() => {
@@ -227,7 +211,7 @@ const App = () => {
     deleteEntry(displayedEventData._id!, displayedEventData.startTimeUtc, false)
       .then(() => {
         getEntries(rangeStart, rangeEnd).then((entries) => {
-          setEventsWithExtraFields(entries);
+          setEventsWithStart(entries);
           setShowDeletionSelectionScreen(false);
           setShowOverlay(false);
         });
@@ -247,7 +231,7 @@ const App = () => {
       deleteEntry(displayedEventData._id!)
         .then(() => {
           getEntries(rangeStart, rangeEnd).then((entries) => {
-            setEventsWithExtraFields(entries);
+            setEventsWithStart(entries);
             setShowOverlay(false);
           });
         })

--- a/ui/src/client.test.ts
+++ b/ui/src/client.test.ts
@@ -422,6 +422,32 @@ describe("client functions", () => {
       });
     });
 
+    it("succeeds for recurring events", async () => {
+      const mockResponse = {
+        status: 200,
+      } as Response;
+
+      const startTime = "2024-06-06T01:07:00.000Z";
+
+      const fetchSpy = jest
+        .spyOn(window, "fetch")
+        .mockResolvedValue(mockResponse);
+
+      const result = await deleteEntry(
+        "638d815856e5c70955565b7e",
+        startTime,
+        false,
+      );
+      expect(fetchSpy).toHaveBeenCalled();
+      expect(fetchSpy.mock.calls[0][1]).toEqual(
+        expect.objectContaining({ method: "DELETE" }),
+      );
+
+      expect(result).toEqual({
+        status: 200,
+      });
+    });
+
     it("throws an error on failure", async () => {
       const mockResponse = {
         status: 400,

--- a/ui/src/client.ts
+++ b/ui/src/client.ts
@@ -174,13 +174,20 @@ const updateEntry = async (
   return result;
 };
 
-const deleteEntry = async (entryId: string) => {
-  const response = await fetch(`http://localhost:4000/entries/${entryId}`, {
-    method: "DELETE",
-    headers: {
-      "Content-Type": "application/json",
+const deleteEntry = async (
+  entryId: string,
+  start?: string,
+  applyToSeries?: boolean,
+) => {
+  const response = await fetch(
+    `http://localhost:4000/entries/${entryId}?start=${start}&applyToSeries=${applyToSeries}`,
+    {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+      },
     },
-  });
+  );
   const result = await response;
   if (notOk(response.status)) {
     throw new Error("Delete entry request failed");


### PR DESCRIPTION
_Closes:_ #120

## Summary of changes
This PR builds out the ability to delete a single instance of a recurring event. It also introduces a new screen asking the user to confirm whether they want to delete the series or the single instance.

## Dev notes

## Testing

- [x] Unit tests

#### Screenshot of UI (local testing in browser)
![Screen Shot 2023-01-16 at 10 30 18 AM](https://user-images.githubusercontent.com/15992415/212745534-dd317ef3-efef-4692-959f-316f2741285b.png)
