### PR TITLE
Cal 86 edit single event in recurring series

### DIFF
--- a/api/app.test.js
+++ b/api/app.test.js
@@ -538,7 +538,7 @@ describe("PATCH / entry", () => {
     );
   });
 
-  it.only("can edit a recurring event", async () => {
+  it("can edit a recurring event", async () => {
     const date = new Date("04 January 2023 14:48 UTC");
     const oneYearLater = yearAfter(date);
 
@@ -670,20 +670,20 @@ describe("PATCH / entry", () => {
       .expect(200);
 
     const updatedExceptionCount = await EntryException.countDocuments();
-    expect(updatedExceptionCount).toEqual(1);
+    expect(updatedExceptionCount).toEqual(2);
 
-    const entryException = await EntryException.find();
-    expect(entryException).toEqual(
-      expect.objectContaining({
-        _id: expect.anything(),
-        eventId: "345",
-        creatorId: "678",
-        title: "Listen to Sweet Surrender",
-        startTimeUtc: updatedStartDate,
-        endTimeUtc: updatedEndDate,
-        description: "by John Denver",
-      }),
+    const entryException = await EntryException.find()
+      .sort({ _id: -1 })
+      .limit(1);
+
+    const modifiedEntryException = entryException[0];
+    expect(modifiedEntryException.entryId.toString()).toEqual(
+      createdEvent._id.toString(),
     );
+    expect(modifiedEntryException.title).toEqual("Listen to Sweet Surrender");
+    expect(modifiedEntryException.description).toEqual("by John Denver");
+    expect(modifiedEntryException.startTimeUtc).toEqual(updatedStartDate);
+    expect(modifiedEntryException.endTimeUtc).toEqual(updatedEndDate);
   });
 
   it("catches and returns an error from CalendarEntry.findByIdAndUpdate", async () => {

--- a/api/app.test.js
+++ b/api/app.test.js
@@ -532,8 +532,10 @@ describe("DELETE / entry?start=<start-time>&applyToSeries=<boolean>", () => {
       })
       .expect(200);
 
-    const exceptionCount = await EntryException.countDocuments();
-    expect(exceptionCount).toEqual(2);
+    const exceptionCount = await EntryException.where("modified")
+      .equals(true)
+      .countDocuments();
+    expect(exceptionCount).toEqual(1);
 
     await supertest(app)
       .delete(
@@ -542,9 +544,10 @@ describe("DELETE / entry?start=<start-time>&applyToSeries=<boolean>", () => {
         }?start=${updatedStartDate.toISOString()}&applyToSeries=false`,
       )
       .expect(200);
-    const updatedExceptionCount = await EntryException.countDocuments();
-    //even though we're checking there's only one exception now it would be good to check that the exception is specifically for deletion
-    expect(updatedExceptionCount).toEqual(1);
+    const updatedExceptionCount = await EntryException.where("modified")
+      .equals(true)
+      .countDocuments();
+    expect(updatedExceptionCount).toEqual(0);
   });
 
   it("cascades deletion to entry exceptions when recurring series is deleted", async () => {

--- a/api/app.test.js
+++ b/api/app.test.js
@@ -337,7 +337,7 @@ describe("GET /entry/:entryId?start=<start-time>", () => {
   });
 });
 
-describe("DELETE / entry", () => {
+describe("DELETE / entry?start=<start-time>&applyToSeries=<boolean>", () => {
   let data;
   const startTime = new Date("05 July 2011 14:48 UTC");
   const endTime = new Date("05 July 2011 14:48 UTC");
@@ -493,7 +493,7 @@ describe("DELETE / entry", () => {
   });
 });
 
-describe("PATCH / entry", () => {
+describe("PATCH / entry?start=<start-time>&applyToSeries=<boolean>", () => {
   let data;
   const startTime = new Date();
   const endTime = new Date();

--- a/api/app.test.js
+++ b/api/app.test.js
@@ -483,6 +483,70 @@ describe("DELETE / entry?start=<start-time>&applyToSeries=<boolean>", () => {
     expect(updatedResponse.body.length).toEqual(10);
   });
 
+  it("deletes an entry exception from a recurring series", async () => {
+    const date = new Date("04 January 2023 14:48 UTC");
+    const oneYearLater = yearAfter(date);
+
+    const createdEventData = await supertest(app)
+      .post("/entries")
+      .send({
+        eventId: "123",
+        creatorId: "456",
+        title: "Happy day",
+        description: "and a happy night too",
+        startTimeUtc: date,
+        endTimeUtc: dayAfter(date),
+        allDay: false,
+        recurring: true,
+        frequency: "monthly",
+        recurrenceEndsUtc: oneYearLater,
+      })
+      .expect(201);
+    const createdEvent = JSON.parse(createdEventData.text);
+
+    const rule = new RRule({
+      freq: RRule.MONTHLY,
+      dtstart: date,
+      until: oneYearLater,
+    });
+
+    const recurrences = rule.all();
+
+    const februaryFourth = recurrences[1];
+
+    const updatedStartDate = new Date("05 February 2023 14:48 UTC");
+    const updatedEndDate = dayAfter(updatedStartDate);
+
+    await supertest(app)
+      .patch(
+        `/entries/${
+          createdEvent._id
+        }?start=${februaryFourth.toISOString()}&applyToSeries=false`,
+      )
+      .send({
+        title: "Listen to Sweet Surrender",
+        startTimeUtc: updatedStartDate,
+        endTimeUtc: updatedEndDate,
+        description: "by John Denver",
+        allDay: false,
+      })
+      .expect(200);
+
+    const exceptionCount = await EntryException.countDocuments();
+    expect(exceptionCount).toEqual(2);
+
+    await supertest(app)
+      .delete(
+        `/entries/${
+          createdEvent._id
+        }?start=${updatedStartDate.toISOString()}&applyToSeries=false`,
+      )
+      .expect(200);
+    const updatedExceptionCount = await EntryException.countDocuments();
+    //even though we're checking there's only one exception now it would be good to check that the exception is specifically for deletion
+    expect(updatedExceptionCount).toEqual(1);
+  });
+
   it("cascades deletion to entry exceptions when recurring series is deleted", async () => {
     const date = new Date("04 January 2023 14:48 UTC");
     const oneYearLater = yearAfter(date);

--- a/api/controllers/calendarEntry.controller.ts
+++ b/api/controllers/calendarEntry.controller.ts
@@ -297,8 +297,26 @@ export const updateCalendarEntry = async (
       updatedEntry.save();
       res.status(200).json(updatedEntry);
     } else if (isRecurringEntry(entryToUpdate) && applyToSeries === "false") {
-      // create exception with fields filled out
-      // update getAll to deal with modified exceptions
+      await EntryException.create({
+        deleted: true,
+        modified: false,
+        entryId: entryToUpdate._id,
+        startTimeUtc: start,
+      });
+
+      const updatedEntry = await EntryException.create({
+        deleted: false,
+        modified: true,
+        entryId: entryToUpdate._id,
+        startTimeUtc: req.body.startTimeUtc,
+        creatorId: req.body.creatorId,
+        title: req.body.title,
+        description: req.body.description,
+        allDay: req.body.allDay,
+        endTimeUtc: req.body.endTimeUtc,
+      });
+      // EB_TODO: we should be returning an expanded instance here, not the exception object
+      res.status(200).json(updatedEntry);
     } else {
       const updatedEntry = await CalendarEntry.findByIdAndUpdate(
         id,

--- a/api/controllers/calendarEntry.controller.ts
+++ b/api/controllers/calendarEntry.controller.ts
@@ -232,7 +232,11 @@ export const getCalendarEntry = async (
         oneMinBefore,
         oneMinAfter,
       );
-      res.status(200).json(expandedEntry[0]);
+      if (expandedEntry.length > 0) {
+        res.status(200).json(expandedEntry[0]);
+      } else {
+        res.status(200).json({});
+      }
     } else {
       res.status(200).json(entry);
     }

--- a/api/controllers/calendarEntry.controller.ts
+++ b/api/controllers/calendarEntry.controller.ts
@@ -57,15 +57,15 @@ const expandModifiedEntryException = async (
   parentCalendarEntry: RecurringEntry,
 ) => {
   return {
-    _id: entryException._id,
-    eventId: entryException.eventId,
-    creatorId: entryException.creatorId,
+    _id: parentCalendarEntry._id,
     title: entryException.title,
     description: entryException.description,
     allDay: entryException.allDay,
     startTimeUtc: entryException.startTimeUtc,
     endTimeUtc: entryException.endTimeUtc,
     recurring: true,
+    eventId: parentCalendarEntry.eventId,
+    creatorId: parentCalendarEntry.creatorId,
     frequency: parentCalendarEntry.frequency,
     recurrenceEndsUtc: parentCalendarEntry.recurrenceEndsUtc,
   };
@@ -111,7 +111,11 @@ const expandRecurringEntry = async (calendarEntry, start, end) => {
   const modifiedExceptions = await EntryException.find({
     entryId: calendarEntry._id,
     modified: true,
-  });
+  })
+    .where("startTimeUtc")
+    .gte(start)
+    .where("startTimeUtc")
+    .lt(end);
 
   const promises = modifiedExceptions.map(async (exception) => {
     return expandModifiedEntryException(exception, calendarEntry);
@@ -339,7 +343,6 @@ export const updateCalendarEntry = async (
         modified: true,
         entryId: entryToUpdate._id,
         startTimeUtc: req.body.startTimeUtc,
-        creatorId: req.body.creatorId,
         title: req.body.title,
         description: req.body.description,
         allDay: req.body.allDay,

--- a/api/controllers/calendarEntry.controller.ts
+++ b/api/controllers/calendarEntry.controller.ts
@@ -113,9 +113,11 @@ const expandRecurringEntry = async (calendarEntry, start, end) => {
     modified: true,
   });
 
-  const expandedExceptionEntries = modifiedExceptions.map((exception) => {
+  const promises = modifiedExceptions.map(async (exception) => {
     return expandModifiedEntryException(exception, calendarEntry);
   });
+
+  const expandedExceptionEntries = await Promise.all(promises);
 
   return expandedRecurringEntries.concat(expandedExceptionEntries);
 };

--- a/api/controllers/calendarEntry.controller.ts
+++ b/api/controllers/calendarEntry.controller.ts
@@ -283,6 +283,15 @@ export const updateCalendarEntry = async (
     await CalendarEntry.findByIdAndUpdate(id, req.body as CalendarEntry);
     const updatedEntry = await CalendarEntry.findById(id);
     res.status(200).json(updatedEntry);
+    if (isRecurringEntry(updatedEntry)) {
+      const rule = new RRule({
+        freq: FREQUENCY_MAPPING[updatedEntry.frequency],
+        dtstart: updatedEntry.startTimeUtc,
+        until: updatedEntry.recurrenceEndsUtc,
+      });
+      updatedEntry.recurrencePattern = rule.toString();
+      updatedEntry.save();
+    }
   } catch (err) {
     res.status(400);
     res.send({ message: err.message });

--- a/api/controllers/calendarEntry.controller.ts
+++ b/api/controllers/calendarEntry.controller.ts
@@ -48,11 +48,6 @@ type RecurringEntry = {
   updatedAt: Date;
 };
 
-// not used right now but will be used in the future
-const isNonRecurringEntry = (entry) => {
-  return (entry as NonRecurringEntry).recurring === false;
-};
-
 const isRecurringEntry = (entry) => {
   return (entry as RecurringEntry).recurring === true;
 };
@@ -71,7 +66,7 @@ const expandModifiedEntryException = async (
     startTimeUtc: entryException.startTimeUtc,
     endTimeUtc: entryException.endTimeUtc,
     recurring: true,
-    frequency: entryException.frequency,
+    frequency: parentCalendarEntry.frequency,
     recurrenceEndsUtc: parentCalendarEntry.recurrenceEndsUtc,
   };
 };
@@ -118,11 +113,11 @@ const expandRecurringEntry = async (calendarEntry, start, end) => {
     modified: true,
   });
 
-  modifiedExceptions.map((exception) => {
+  const expandedExceptionEntries = modifiedExceptions.map((exception) => {
     return expandModifiedEntryException(exception, calendarEntry);
   });
 
-  return expandedRecurringEntries.concat(modifiedExceptions);
+  return expandedRecurringEntries.concat(expandedExceptionEntries);
 };
 
 export const seedDatabaseWithEntry = async (

--- a/api/models/entryException.js
+++ b/api/models/entryException.js
@@ -15,10 +15,6 @@ const entryExceptionSchema = new mongoose.Schema(
       ref: "CalendarEntry",
       required: true,
     },
-    creatorId: {
-      type: String,
-      required: false,
-    },
     title: {
       type: String,
       required: false,

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -325,6 +325,7 @@ describe("App", () => {
 
         await (await screen.findByText("Save")).click();
       });
+
       expect(
         await screen.findByText(
           "Would you like to edit the entire recurring series or just this event?",

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -277,6 +277,70 @@ describe("App", () => {
       );
     });
 
+    it("allows for editing a single instance of recurring event", async () => {
+      mockGetEntries.mockResolvedValue([
+        {
+          _id: "123",
+          end: "2022-02-27T05:43:37.868Z",
+          start: "2022-02-27T05:43:37.868Z",
+          title: "Berta goes to the baseball game!",
+          recurring: true,
+        },
+        {
+          _id: "345",
+          end: "2022-02-24T05:43:37.868Z",
+          start: "2022-02-24T05:43:37.868Z",
+          title: "Dance",
+          recurring: true,
+        },
+      ]);
+
+      mockGetEntry.mockResolvedValue({
+        _id: "345",
+        end: "2022-02-24T05:43:37.868Z",
+        startTimeUtc: "2022-02-24T05:43:37.868Z",
+        title: "Dance",
+        description: "fun times",
+        recurring: true,
+      });
+
+      mockUpdateEntry.mockResolvedValue(new Response());
+      await act(async () => {
+        await render(<App />);
+      });
+      const eventText = await screen.findByText("Dance");
+      expect(eventText).toBeInTheDocument();
+      await act(async () => {
+        await eventText.click();
+      });
+      expect(mockGetEntry).toHaveBeenCalledTimes(1);
+
+      const editButton = await screen.findByText("Edit");
+      await act(async () => {
+        await editButton.click();
+        userEvent.type(
+          screen.getByLabelText("Description"),
+          " at the grand royale",
+        );
+
+        await (await screen.findByText("Save")).click();
+      });
+      expect(
+        await screen.findByText(
+          "Would you like to edit the entire recurring series or just this event?",
+        ),
+      ).toBeInTheDocument();
+      await act(async () => {
+        await userEvent.click(screen.getByText("Edit this one event"));
+      });
+      expect(mockUpdateEntry).toHaveBeenCalledWith(
+        "345",
+        { here: "should break" },
+        "2022-02-24T05:43:37.868Z",
+        false,
+      );
+    });
+
     it("automatically sets end date when start date is selected", async () => {
       mockCreateEntry.mockResolvedValue({});
       mockGetEntries.mockResolvedValue([]);

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -299,9 +299,11 @@ describe("App", () => {
         _id: "345",
         end: "2022-02-24T05:43:37.868Z",
         startTimeUtc: "2022-02-24T05:43:37.868Z",
+        endTimeUtc: "2022-02-25T05:43:37.868Z",
         title: "Dance",
         description: "fun times",
         recurring: true,
+        recurrenceEndUtc: "2023-02-24T05:43:37.868Z",
       });
 
       mockUpdateEntry.mockResolvedValue(new Response());
@@ -316,14 +318,20 @@ describe("App", () => {
       expect(mockGetEntry).toHaveBeenCalledTimes(1);
 
       const editButton = await screen.findByText("Edit");
+      expect(editButton).toBeInTheDocument();
       await act(async () => {
         await editButton.click();
-        userEvent.type(
-          screen.getByLabelText("Description"),
-          " at the grand royale",
-        );
+      });
 
-        await (await screen.findByText("Save")).click();
+      userEvent.type(
+        screen.getByLabelText("Description"),
+        " at the grand royale",
+      );
+
+      const saveButton = await screen.findByText("Save");
+      expect(saveButton).toBeInTheDocument();
+      await act(async () => {
+        await saveButton.click();
       });
 
       expect(
@@ -336,7 +344,10 @@ describe("App", () => {
       });
       expect(mockUpdateEntry).toHaveBeenCalledWith(
         "345",
-        { here: "should break" },
+        expect.objectContaining({
+          title: "Dance",
+          description: "fun times at the grand royale",
+        }),
         "2022-02-24T05:43:37.868Z",
         false,
       );

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -276,85 +276,68 @@ const App = () => {
       recurrenceEndUtc = new Date(getDateTimeString(recurrenceEnds, startTime));
     }
 
-    setPendingEdits({
-      title,
-      description,
-      startTimeUtc,
-      endTimeUtc,
-      allDay,
-      recurring,
-      frequency,
-      recurrenceBegins,
-      recurrenceEndUtc,
-    });
-    setShowEditSelectionScreen(true);
-    setInEditMode(false);
+    if (displayedEventData.recurring) {
+      setPendingEdits({
+        title,
+        description,
+        startTimeUtc,
+        endTimeUtc,
+        allDay,
+        recurring,
+        frequency,
+        recurrenceBegins,
+        recurrenceEndUtc,
+      });
+      setShowEditSelectionScreen(true);
+      setInEditMode(false);
+    } else {
+      // do the normal update
+    }
+  };
+
+  const handleEditRecurring = ({
+    applyToSeries,
+  }: {
+    applyToSeries: boolean;
+  }) => {
+    const entryId = displayedEventData._id;
+
+    updateEntry(
+      entryId,
+      {
+        title: pendingEdits.title,
+        description: pendingEdits.description,
+        startTimeUtc: pendingEdits.startTimeUtc,
+        endTimeUtc: pendingEdits.endTimeUtc,
+        allDay: pendingEdits.allDay,
+        recurring: pendingEdits.recurring,
+        frequency: pendingEdits.frequency,
+        recurrenceBegins: pendingEdits.recurrenceBegins,
+        recurrenceEndUtc: pendingEdits.recurrenceEndUtc,
+      },
+      displayedEventData.startTimeUtc,
+      applyToSeries,
+    )
+      .then(() => {
+        getEntries(rangeStart, rangeEnd).then((entries) => {
+          setEventsWithStart(entries);
+        });
+        setShowOverlay(false);
+        setShowEditSelectionScreen(false);
+      })
+      .catch(() => {
+        setShowOverlay(false);
+        setShowEditSelectionScreen(false);
+        flashApiErrorMessage();
+      });
   };
 
   const handleEditSeries = () => {
-    const entryId = displayedEventData._id;
-
-    updateEntry(
-      entryId,
-      {
-        title: pendingEdits.title,
-        description: pendingEdits.description,
-        startTimeUtc: pendingEdits.startTimeUtc,
-        endTimeUtc: pendingEdits.endTimeUtc,
-        allDay: pendingEdits.allDay,
-        recurring: pendingEdits.recurring,
-        frequency: pendingEdits.frequency,
-        recurrenceBegins: pendingEdits.recurrenceBegins,
-        recurrenceEndUtc: pendingEdits.recurrenceEndUtc,
-      },
-      displayedEventData.startTimeUtc,
-      true,
-    )
-      .then(() => {
-        getEntries(rangeStart, rangeEnd).then((entries) => {
-          setEventsWithStart(entries);
-        });
-        setShowOverlay(false);
-        setShowEditSelectionScreen(false);
-      })
-      .catch(() => {
-        setShowOverlay(false);
-        setShowEditSelectionScreen(false);
-        flashApiErrorMessage();
-      });
+    handleEditRecurring({ applyToSeries: true });
   };
 
   const handleEditRecurringInstance = () => {
-    const entryId = displayedEventData._id;
-
-    updateEntry(
-      entryId,
-      {
-        title: pendingEdits.title,
-        description: pendingEdits.description,
-        startTimeUtc: pendingEdits.startTimeUtc,
-        endTimeUtc: pendingEdits.endTimeUtc,
-        allDay: pendingEdits.allDay,
-        recurring: pendingEdits.recurring,
-        frequency: pendingEdits.frequency,
-        recurrenceBegins: pendingEdits.recurrenceBegins,
-        recurrenceEndUtc: pendingEdits.recurrenceEndUtc,
-      },
-      displayedEventData.startTimeUtc,
-      false,
-    )
-      .then(() => {
-        getEntries(rangeStart, rangeEnd).then((entries) => {
-          setEventsWithStart(entries);
-        });
-        setShowOverlay(false);
-        setShowEditSelectionScreen(false);
-      })
-      .catch(() => {
-        setShowOverlay(false);
-        setShowEditSelectionScreen(false);
-        flashApiErrorMessage();
-      });
+    handleEditRecurring({ applyToSeries: false });
   };
 
   return (

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -284,10 +284,10 @@ const App = () => {
       recurrenceEndUtc,
     })
       .then(() => {
-        getEntryDetails(entryId);
         getEntries(rangeStart, rangeEnd).then((entries) => {
           setEventsWithStart(entries);
         });
+        setShowOverlay(false);
       })
       .catch(() => {
         setShowOverlay(false);

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -291,7 +291,28 @@ const App = () => {
       setShowEditSelectionScreen(true);
       setInEditMode(false);
     } else {
-      // do the normal update
+      updateEntry(displayedEventData._id, {
+        title,
+        description,
+        startTimeUtc,
+        endTimeUtc,
+        allDay,
+        recurring,
+        frequency,
+        recurrenceBegins,
+        recurrenceEndUtc,
+      })
+        .then(() => {
+          getEntries(rangeStart, rangeEnd).then((entries) => {
+            setEventsWithStart(entries);
+          });
+          setShowOverlay(false);
+          setInEditMode(false);
+        })
+        .catch(() => {
+          setShowOverlay(false);
+          flashApiErrorMessage();
+        });
     }
   };
 

--- a/ui/src/client.test.ts
+++ b/ui/src/client.test.ts
@@ -348,17 +348,22 @@ describe("client functions", () => {
         .spyOn(window, "fetch")
         .mockResolvedValue(mockResponse);
 
-      const result = await updateEntry("638d815856e5c70955565b7e", {
-        title: "Barbies's Bat Mitzvah",
-        description: "Barbie is turning 13!",
-        startTimeUtc: new Date("2024-06-06T01:07:00.000Z"),
-        endTimeUtc: new Date("2024-06-06T01:07:00.000Z"),
-        allDay: true,
-        recurring: true,
-        frequency: "monthly",
-        recurrenceBegins: new Date("2024-06-06T01:07:00.000Z"),
-        recurrenceEndUtc: new Date("2025-06-06T01:07:00.000Z"),
-      });
+      const result = await updateEntry(
+        "638d815856e5c70955565b7e",
+        {
+          title: "Barbies's Bat Mitzvah",
+          description: "Barbie is turning 13!",
+          startTimeUtc: new Date("2024-06-06T01:07:00.000Z"),
+          endTimeUtc: new Date("2024-06-06T01:07:00.000Z"),
+          allDay: true,
+          recurring: true,
+          frequency: "monthly",
+          recurrenceBegins: new Date("2024-06-06T01:07:00.000Z"),
+          recurrenceEndUtc: new Date("2025-06-06T01:07:00.000Z"),
+        },
+        "2024-06-06T01:07:00.000Z",
+        true,
+      );
       expect(fetchSpy).toHaveBeenCalled();
       expect(result).toEqual({
         _id: "638d815856e5c70955565b7e",

--- a/ui/src/client.ts
+++ b/ui/src/client.ts
@@ -127,28 +127,33 @@ const updateEntry = async (
     recurrenceBegins,
     recurrenceEndUtc,
   }: CalendarEntryInput,
+  start?: string,
+  applyToSeries?: boolean,
 ) => {
   let response;
   if (recurring) {
-    response = await fetch(`http://localhost:4000/entries/${entryId}`, {
-      method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
+    response = await fetch(
+      `http://localhost:4000/entries/${entryId}?start=${start}&applyToSeries=${applyToSeries}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          description: description,
+          title: title,
+          creatorId: "1234",
+          eventId: "5678",
+          startTimeUtc: startTimeUtc.toISOString(),
+          endTimeUtc: endTimeUtc.toISOString(),
+          allDay,
+          recurring,
+          frequency,
+          recurrenceBegins: recurrenceBegins?.toISOString(),
+          recurrenceEnds: recurrenceEndUtc?.toISOString(),
+        }),
       },
-      body: JSON.stringify({
-        description: description,
-        title: title,
-        creatorId: "1234",
-        eventId: "5678",
-        startTimeUtc: startTimeUtc.toISOString(),
-        endTimeUtc: endTimeUtc.toISOString(),
-        allDay,
-        recurring,
-        frequency,
-        recurrenceBegins: recurrenceBegins?.toISOString(),
-        recurrenceEnds: recurrenceEndUtc?.toISOString(),
-      }),
-    });
+    );
   } else {
     response = await fetch(`http://localhost:4000/entries/${entryId}`, {
       method: "PATCH",

--- a/ui/src/client.ts
+++ b/ui/src/client.ts
@@ -1,4 +1,4 @@
-interface CalendarEntryInput {
+export interface CalendarEntryInput {
   title: string;
   description: string;
   startTimeUtc: Date;


### PR DESCRIPTION
_Closes:_ #86

## Summary of changes
This PR builds out the ability to edit a single event in a recurring series. Since this involves creating entry exceptions, we also need to make updates to the GET, DELETE, and UPDATE endpoints to ensure they all worked for entry exceptions as well.

## Dev notes

## Testing

- [x] Unit tests

#### Screenshot of UI (local testing in browser)
